### PR TITLE
kubeadm: init: Use cilium k8s yaml from package

### DIFF
--- a/pkg/kubeadm/initMaster.go
+++ b/pkg/kubeadm/initMaster.go
@@ -134,7 +134,7 @@ func InitMaster(in *pb.InitRequest, stream pb.Kubeadm_InitMasterServer) error {
 		if err := stream.Send(&pb.StatusReply{Success: true, Message: "Deploy cilium"}); err != nil {
 			return err
 		}
-		success, message = ExecuteCmd("kubectl", "--kubeconfig=/etc/kubernetes/admin.conf",  "apply", "-f", "https://raw.githubusercontent.com/kubic-project/k8s-manifests/cilium/cilium.yaml")
+		success, message = ExecuteCmd("kubectl", "--kubeconfig=/etc/kubernetes/admin.conf",  "apply", "-f", "/usr/share/k8s-yaml/cilium/cilium.yaml")
 		if success != true {
 			ResetMaster()
 			if err := stream.Send(&pb.StatusReply{Success: success, Message: message}); err != nil {


### PR DESCRIPTION
Please merge **after** the following SR is accepted:

https://build.opensuse.org/request/show/705279

---

Cilium k8s yaml manifest is now available as a package which should be
installed as a part of kubeadm pattern.

Fixes: #1
Fixes: eecc29e8c37d ("Use cilium.yaml from master branch")

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>