### PR TITLE
[Untested] add new parameter apiserver_cert_extra_sans

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ harddisk, install the new node and, if this new node is of type "master" or
   * `--haproxy=<salt name>` Adjust haproxy configuration for multi-master setup via salt
   * `--pod-network=<flannel|cilium>`	Pod network
   * `--adv-addr=<IPaddr>`	IP address the API Server will advertise on
+  * `--apiserver_cert_extra_sans=<IPaddr>`	additional IPs to add to the APIserver certificate
   * `--stage=<official|devel>` Specify to use the official images or from the devel project
 * kubeconfig - Download kubeconfig
   * `--output=<file>` - Where the kubeconfig file should be stored

--- a/api/api.proto
+++ b/api/api.proto
@@ -63,6 +63,7 @@ message InitRequest {
   string stage = 6;
   // salt name of first master
   string first_master = 7;
+  string apiserver_cert_extra_sans = 8;
 }
 
 // The upgrade request

--- a/pkg/kubeadm/initMaster.go
+++ b/pkg/kubeadm/initMaster.go
@@ -209,6 +209,10 @@ func InitMaster(in *pb.InitRequest, stream pb.Kubeadm_InitMasterServer) error {
 		kubeadm_args = append(kubeadm_args, "--apiserver-advertise-address=" + in.AdvAddr)
 	}
 
+	if len(in.CertExtraSans) > 0 {
+		kubeadm_args = append(kubeadm_args, "--apiserver-cert-extra-sans=" + in.CertExtraSans)
+	}
+
 	if strings.EqualFold(arg_pod_network, "flannel") {
 		kubeadm_args = append(kubeadm_args, "--pod-network-cidr=10.244.0.0/16")
 	}

--- a/pkg/kubicctl/initMaster.go
+++ b/pkg/kubicctl/initMaster.go
@@ -71,7 +71,7 @@ func initMaster(cmd *cobra.Command, args []string) {
 	defer cancel()
 
 	fmt.Print ("Initializing kubernetes master can take several minutes, please be patient.\n")
-	stream, err := client.InitMaster(ctx, &pb.InitRequest{PodNetworking: podNetwork, AdvAddr: adv_addr, MultiMaster: multiMaster, KubernetesVersion: kubernetesVersion, Stage: stage, Haproxy: haproxy, FirstMaster: firstMaster})
+	stream, err := client.InitMaster(ctx, &pb.InitRequest{PodNetworking: podNetwork, AdvAddr: adv_addr, CertExtraSans: apiserver_cert_extra_sans, MultiMaster: multiMaster, KubernetesVersion: kubernetesVersion, Stage: stage, Haproxy: haproxy, FirstMaster: firstMaster})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not initialize: %v\n", err)
 		return

--- a/pkg/kubicctl/initMaster.go
+++ b/pkg/kubicctl/initMaster.go
@@ -28,6 +28,7 @@ import (
 var (
 	podNetwork = "weave"
 	adv_addr = ""
+	apiserver_cert_extra_sans = ""
 	multiMaster = ""
 	kubernetesVersion = ""
 	stage = ""
@@ -46,6 +47,7 @@ func InitMasterCmd() *cobra.Command {
         subCmd.PersistentFlags().StringVar(&multiMaster, "multi-master", multiMaster, "Setup multimaster cluster, argument needs to be the DNS name of the load balancer")
         subCmd.PersistentFlags().StringVar(&podNetwork, "pod-network", podNetwork, "pod network, valid values are 'cilium', 'flannel' or 'weave'")
         subCmd.PersistentFlags().StringVar(&adv_addr, "adv-addr", adv_addr, "IP address the API Server will advertise it's listening on")
+        subCmd.PersistentFlags().StringVar(&apiserver_cert_extra_sans, "apiserver_cert_extra_sans", apiserver_cert_extra_sans, "additional IPs to add to the APIserver certificate")
         subCmd.PersistentFlags().StringVar(&kubernetesVersion, "kubernetes-version", kubernetesVersion, "Kubernetes version of the control plane to deploy")
 	subCmd.PersistentFlags().StringVar(&stage, "stage", stage, "Stage of development: 'official', 'devel'")
 	subCmd.PersistentFlags().StringVar(&haproxy, "haproxy", haproxy, "Name of salt minion running haproxy as loadbalancer")


### PR DESCRIPTION
See my mail to the kubic list:
https://lists.opensuse.org/opensuse-kubic/2020-04/msg00020.html

As I am no go programmer, I have no idea what might be missing. I added that parameter where `adv_addr` was present. Not sure about the `api/api.proto`  thingy.
