### PR TITLE
Add a way to deploy kubic withou a CNI (--pod-network=none)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ is installed.
 For cilium or flannel instead of weave you have to use `kubicctl init
 --pod-network cilium` or `kubicctl init --pod-network flannel`.
 
-To deploy kubic without à CNI you have to use `kubicctl init 
+To deploy kubic without a CNI you have to use `kubicctl init 
 --pod-network none`
 
 To add additional worker nodes:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ is installed.
 For cilium or flannel instead of weave you have to use `kubicctl init
 --pod-network cilium` or `kubicctl init --pod-network flannel`.
 
+To deploy kubic without à CNI you have to use `kubicctl init 
+--pod-network none`
+
 To add additional worker nodes:
 
 ```

--- a/cmd/haproxycfg/main.go
+++ b/cmd/haproxycfg/main.go
@@ -17,35 +17,36 @@ package main
 import (
 	"os"
 
-        log "github.com/sirupsen/logrus"
-        "github.com/spf13/cobra"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
+
 var (
-        Version = "unreleased"
+	Version   = "unreleased"
 	OutputDir = "/etc/haproxy"
 )
 
 func ServerCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "server",
-                Short: "Manage server entry of k8s-api backend",
-        }
+	var subCmd = &cobra.Command{
+		Use:   "server",
+		Short: "Manage server entry of k8s-api backend",
+	}
 
-        subCmd.AddCommand(
-                ServerAddCmd(),
+	subCmd.AddCommand(
+		ServerAddCmd(),
 		ServerRemoveCmd(),
-        )
+	)
 
-        return subCmd
+	return subCmd
 }
 
 func main() {
 	rootCmd := &cobra.Command{
-                Use:   "haproxycfg",
-                Short: "Kubic haproxy.cfg configurator"}
+		Use:   "haproxycfg",
+		Short: "Kubic haproxy.cfg configurator"}
 	rootCmd.Version = Version
 	rootCmd.AddCommand(
-                VersionCmd(),
+		VersionCmd(),
 		InitializeConfigCmd(),
 		ServerCmd(),
 	)
@@ -53,6 +54,6 @@ func main() {
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal(err)
 		os.Exit(1)
-        }
+	}
 	os.Exit(0)
 }

--- a/cmd/kubicctl/main.go
+++ b/cmd/kubicctl/main.go
@@ -15,8 +15,8 @@
 package main
 
 import (
-	"os"
 	"github.com/thkukuk/kubic-control/pkg/kubicctl"
+	"os"
 )
 
 func main() {

--- a/pkg/certificate_server/createCert.go
+++ b/pkg/certificate_server/createCert.go
@@ -15,11 +15,11 @@
 package certificate
 
 import (
-	"os"
-        "os/exec"
-        "fmt"
-        "bytes"
+	"bytes"
+	"fmt"
 	"io/ioutil"
+	"os"
+	"os/exec"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -28,35 +28,34 @@ import (
 
 var PKI_dir = "/etc/kubicd/pki"
 
-func ExecuteCmd(command string, arg ...string) (bool,string) {
-        var out bytes.Buffer
-        var stderr bytes.Buffer
+func ExecuteCmd(command string, arg ...string) (bool, string) {
+	var out bytes.Buffer
+	var stderr bytes.Buffer
 
-        cmd := exec.Command(command, arg...)
-        cmd.Stdout = &out
-        cmd.Stderr = &stderr
+	cmd := exec.Command(command, arg...)
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
 
-        //log.Info(cmd)
+	//log.Info(cmd)
 
-        if err := cmd.Run(); err != nil {
+	if err := cmd.Run(); err != nil {
 		errorstr := strings.TrimSpace(stderr.String())
-                log.Error("Error invoking " + command + ": " + fmt.Sprint(err) + "\n" + errorstr)
-                return false, "Error invoking " + command + ": " + err.Error() + " \n(" + errorstr + ")"
-        } else {
-                log.Info(out.String())
-        }
+		log.Error("Error invoking " + command + ": " + fmt.Sprint(err) + "\n" + errorstr)
+		return false, "Error invoking " + command + ": " + err.Error() + " \n(" + errorstr + ")"
+	} else {
+		log.Info(out.String())
+	}
 
-        return true, out.String()
+	return true, out.String()
 }
 
-
-func CreateUser (pki_dir string, cn string) (bool, string) {
+func CreateUser(pki_dir string, cn string) (bool, string) {
 	return ExecuteCmd("certstrap", "--depot-path", pki_dir,
 		"request-cert", "--common-name", cn, "--passphrase", "")
 }
 
-func SignUser (pki_dir string, cn string) (bool, string) {
-        return ExecuteCmd("certstrap", "--depot-path", pki_dir, "sign",
+func SignUser(pki_dir string, cn string) (bool, string) {
+	return ExecuteCmd("certstrap", "--depot-path", pki_dir, "sign",
 		cn, "--CA", "Kubic-Control-CA")
 }
 
@@ -64,24 +63,24 @@ func CreateCert(in *pb.CreateCertRequest) (bool, string, string, string) {
 
 	user := in.Name
 
-        success, message := CreateUser(PKI_dir, user)
-        if success != true {
-                return success, message, "", ""
-        }
-        success, message = SignUser(PKI_dir, user)
-        if  success != true {
-                return success, message, "", ""
-        }
+	success, message := CreateUser(PKI_dir, user)
+	if success != true {
+		return success, message, "", ""
+	}
+	success, message = SignUser(PKI_dir, user)
+	if success != true {
+		return success, message, "", ""
+	}
 
 	content_key, err := ioutil.ReadFile(PKI_dir + "/" + user + ".key")
-        if err != nil {
-                return false, err.Error(), "", ""
-        }
+	if err != nil {
+		return false, err.Error(), "", ""
+	}
 
 	content_crt, err := ioutil.ReadFile(PKI_dir + "/" + user + ".crt")
-        if err != nil {
-                return false, err.Error(), "", ""
-        }
+	if err != nil {
+		return false, err.Error(), "", ""
+	}
 
 	os.Remove(PKI_dir + "/" + user + ".key")
 	os.Remove(PKI_dir + "/" + user + ".crt")

--- a/pkg/deployment/deployFile.go
+++ b/pkg/deployment/deployFile.go
@@ -15,8 +15,8 @@
 package deployment
 
 import (
-        "gopkg.in/ini.v1"
-        "github.com/thkukuk/kubic-control/pkg/tools"
+	"github.com/thkukuk/kubic-control/pkg/tools"
+	"gopkg.in/ini.v1"
 )
 
 func DeployFile(yamlName string) (bool, string) {
@@ -32,13 +32,13 @@ func DeployFile(yamlName string) (bool, string) {
 	cfg, err := ini.LooseLoad("/var/lib/kubic-control/k8s-yaml.conf")
 	if err != nil {
 		return false, "Cannot load k8s-yaml.conf: " + err.Error()
-        }
+	}
 
 	cfg.Section("").Key(yamlName).SetValue(result)
 	err = cfg.SaveTo("/var/lib/kubic-control/k8s-yaml.conf")
-        if err != nil {
+	if err != nil {
 		return false, "Cannot write k8s-yaml.conf: " + err.Error()
-        }
+	}
 
 	return true, ""
 }

--- a/pkg/deployment/deployHelm.go
+++ b/pkg/deployment/deployHelm.go
@@ -2,23 +2,23 @@ package deployment
 
 import (
 	"errors"
-        "gopkg.in/ini.v1"
-        "github.com/thkukuk/kubic-control/pkg/tools"
+	"github.com/thkukuk/kubic-control/pkg/tools"
+	"gopkg.in/ini.v1"
 )
 
-const(
-	helmConfig = "/var/lib/kubic-control/k8s-helm.conf"
+const (
+	helmConfig      = "/var/lib/kubic-control/k8s-helm.conf"
 	adminKubeconfig = "/etc/kubernetes/admin.conf"
 )
 
-func setHelmConfig(chartName, releaseName, valuesPath, namespace string) error{
+func setHelmConfig(chartName, releaseName, valuesPath, namespace string) error {
 
 	var success bool
 	var message string
-	if valuesPath == ""{
+	if valuesPath == "" {
 		success, message = tools.ExecuteCmd("helm", "template", releaseName,
 			chartName, "--kubeconfig="+adminKubeconfig)
-	}else{
+	} else {
 		success, message = tools.ExecuteCmd("helm", "template", releaseName,
 			chartName, "--kubeconfig="+adminKubeconfig,
 			"-f", valuesPath)
@@ -27,24 +27,23 @@ func setHelmConfig(chartName, releaseName, valuesPath, namespace string) error{
 	if success != true {
 		return errors.New(message)
 	}
-	
+
 	result, err := tools.Sha256sum_b(message)
 
 	cfg, err := ini.LooseLoad(helmConfig)
 	if err != nil {
 		return err
-        }
+	}
 
 	cfg.Section("").Key(chartName).SetValue(result)
-	cfg.Section("").Key(chartName+".releaseName").SetValue(releaseName)
-	cfg.Section("").Key(chartName+".valuesPath").SetValue(valuesPath)
-	cfg.Section("").Key(chartName+".namespace").SetValue(namespace)
+	cfg.Section("").Key(chartName + ".releaseName").SetValue(releaseName)
+	cfg.Section("").Key(chartName + ".valuesPath").SetValue(valuesPath)
+	cfg.Section("").Key(chartName + ".namespace").SetValue(namespace)
 
-	
 	err = cfg.SaveTo(helmConfig)
-        if err != nil {
+	if err != nil {
 		return err
-        }
+	}
 	return nil
 }
 
@@ -55,17 +54,17 @@ func DeployHelm(chartName, releaseName, valuesPath, namespace string) error {
 	if namespace == "" {
 		namespace = "default"
 	}
-	if valuesPath == ""{
+	if valuesPath == "" {
 		success, message = tools.ExecuteCmd("helm", "install", releaseName,
 			chartName, "--kubeconfig=/etc/kubernetes/admin.conf",
 			"--namespace", namespace)
-	}else{
+	} else {
 		success, message = tools.ExecuteCmd("helm", "install", releaseName,
 			chartName, "--kubeconfig=/etc/kubernetes/admin.conf",
 			"-f", valuesPath,
 			"--namespace", namespace)
 	}
-	
+
 	if success != true {
 		return errors.New(message)
 	}

--- a/pkg/deployment/deployKustomize.go
+++ b/pkg/deployment/deployKustomize.go
@@ -15,11 +15,11 @@
 package deployment
 
 import (
-	"strings"
 	"os"
+	"strings"
 
-        "gopkg.in/ini.v1"
-        "github.com/thkukuk/kubic-control/pkg/tools"
+	"github.com/thkukuk/kubic-control/pkg/tools"
+	"gopkg.in/ini.v1"
 )
 
 const (
@@ -121,17 +121,17 @@ func DeployKustomize(service string, argument string) (bool, string) {
 	}
 
 	os.RemoveAll(StateDir + "/kustomize/" + service)
-	err := os.MkdirAll(StateDir + "/kustomize/" + service + "/overlay",
+	err := os.MkdirAll(StateDir+"/kustomize/"+service+"/overlay",
 		os.ModePerm)
 	if err != nil {
 		return false, "Cannot create " + StateDir + "/kustomize/" + service + "/overlay: " + err.Error()
-        }
-	err = os.Symlink("/usr/share/k8s-yaml/" +service,
-		StateDir + "/kustomize/"+ service + "/base")
+	}
+	err = os.Symlink("/usr/share/k8s-yaml/"+service,
+		StateDir+"/kustomize/"+service+"/base")
 	if err != nil {
 		return false, "Cannot link " + service +
 			" base directory: " + err.Error()
-        }
+	}
 
 	switch service {
 	case "metallb":
@@ -148,7 +148,7 @@ func DeployKustomize(service string, argument string) (bool, string) {
 		}
 	}
 	retval, message := tools.ExecuteCmd("kustomize", "build",
-		StateDir + "/kustomize/" + service + "/overlay")
+		StateDir+"/kustomize/"+service+"/overlay")
 	if retval != true {
 		os.RemoveAll(StateDir + "/kustomize/" + service)
 		return false, message
@@ -165,10 +165,10 @@ func DeployKustomize(service string, argument string) (bool, string) {
 	}
 	f.Close()
 
-	result, err := tools.Sha256sum_f(StateDir + "/kustomize/" + service + "/" + service + ".yaml");
+	result, err := tools.Sha256sum_f(StateDir + "/kustomize/" + service + "/" + service + ".yaml")
 	retval, message = tools.ExecuteCmd("kubectl",
-                "--kubeconfig=/etc/kubernetes/admin.conf", "apply", "-f",
-		StateDir + "/kustomize/" + service + "/" + service + ".yaml")
+		"--kubeconfig=/etc/kubernetes/admin.conf", "apply", "-f",
+		StateDir+"/kustomize/"+service+"/"+service+".yaml")
 	if retval != true {
 		return false, message
 	}
@@ -176,7 +176,7 @@ func DeployKustomize(service string, argument string) (bool, string) {
 	if strings.EqualFold(service, "metallb") && !yamlDidExist {
 		retval, message = tools.ExecuteCmd("kubectl",
 			"--kubeconfig=/etc/kubernetes/admin.conf", "create",
-			"secret", "generic", "-n",  "metallb-system",
+			"secret", "generic", "-n", "metallb-system",
 			"memberlist", "--from-literal=secretkey=\"$(openssl rand -base64 128)\"")
 		if retval != true {
 			return false, message
@@ -190,9 +190,9 @@ func DeployKustomize(service string, argument string) (bool, string) {
 
 	cfg.Section("").Key(service).SetValue(result)
 	err = cfg.SaveTo(StateDir + "/k8s-kustomize.conf")
-        if err != nil {
+	if err != nil {
 		return false, "Cannot write k8s-kustomize.conf: " + err.Error()
-        }
+	}
 
 	return true, ""
 }

--- a/pkg/deployment/updateAll.go
+++ b/pkg/deployment/updateAll.go
@@ -15,9 +15,9 @@
 package deployment
 
 import (
-	"gopkg.in/ini.v1"
 	log "github.com/sirupsen/logrus"
 	"github.com/thkukuk/kubic-control/pkg/tools"
+	"gopkg.in/ini.v1"
 )
 
 func UpdateAll(forced bool) (bool, string) {
@@ -25,7 +25,7 @@ func UpdateAll(forced bool) (bool, string) {
 	cfg, err := ini.Load("/var/lib/kubic-control/k8s-yaml.conf")
 	if err != nil {
 		return false, "Cannot load k8s-yaml.conf: " + err.Error()
-        }
+	}
 
 	keys := cfg.Section("").KeyStrings()
 	for _, key := range keys {
@@ -51,12 +51,11 @@ func UpdateAll(forced bool) (bool, string) {
 		}
 	}
 
-
 	// Update kustomize installed services
 	cfg, err = ini.Load("/var/lib/kubic-control/k8s-kustomize.conf")
 	if err != nil {
 		return false, "Cannot load k8s-kustomize.conf: " + err.Error()
-        }
+	}
 
 	keys = cfg.Section("").KeyStrings()
 	for _, key := range keys {
@@ -68,7 +67,7 @@ func UpdateAll(forced bool) (bool, string) {
 			}
 		} else {
 			retval, message := tools.ExecuteCmd("kustomize", "build",
-				StateDir + "/kustomize/" + key + "/overlay")
+				StateDir+"/kustomize/"+key+"/overlay")
 			if retval != true {
 				return retval, message
 			}
@@ -92,13 +91,13 @@ func UpdateAll(forced bool) (bool, string) {
 	cfg, err = ini.Load("/var/lib/kubic-control/k8s-helm.conf")
 	if err != nil {
 		return false, "Cannot load k8s-helm.conf: " + err.Error()
-        }
+	}
 
 	keys = cfg.Section("").KeyStrings()
 	for _, chartName := range keys {
-		releaseName := cfg.Section("").Key(chartName+".releaseName").String()
-		valuesPath := cfg.Section("").Key(chartName+".valuesPath").String()
-		namespace := cfg.Section("").Key(chartName+".namespace").String()
+		releaseName := cfg.Section("").Key(chartName + ".releaseName").String()
+		valuesPath := cfg.Section("").Key(chartName + ".valuesPath").String()
+		namespace := cfg.Section("").Key(chartName + ".namespace").String()
 		if forced {
 			// force, so always update even if not changed
 			err = UpdateHelm(chartName, releaseName, valuesPath, namespace)
@@ -108,7 +107,7 @@ func UpdateAll(forced bool) (bool, string) {
 		} else {
 			hash := cfg.Section("").Key(chartName).String()
 			needsUpdate, err := checkHelmUpdate(chartName, releaseName, valuesPath, namespace, hash)
-			if err != nil{
+			if err != nil {
 				return false, err.Error()
 			}
 			if needsUpdate {
@@ -118,10 +117,10 @@ func UpdateAll(forced bool) (bool, string) {
 					return false, err.Error()
 				}
 			} else {
-				log.Infof("%s has not changed, ignoring",)
+				log.Infof("%s has not changed, ignoring")
 			}
 		}
 	}
-	
- 	return true, ""
+
+	return true, ""
 }

--- a/pkg/deployment/updateFile.go
+++ b/pkg/deployment/updateFile.go
@@ -15,8 +15,8 @@
 package deployment
 
 import (
-        "gopkg.in/ini.v1"
-        "github.com/thkukuk/kubic-control/pkg/tools"
+	"github.com/thkukuk/kubic-control/pkg/tools"
+	"gopkg.in/ini.v1"
 )
 
 func UpdateFile(yamlName string) (bool, string) {
@@ -33,13 +33,13 @@ func UpdateFile(yamlName string) (bool, string) {
 	cfg, err := ini.LooseLoad("/var/lib/kubic-control/k8s-yaml.conf")
 	if err != nil {
 		return false, "Cannot load k8s-yaml.conf: " + err.Error()
-        }
+	}
 
 	cfg.Section("").Key(yamlName).SetValue(result)
 	err = cfg.SaveTo("/var/lib/kubic-control/k8s-yaml.conf")
-        if err != nil {
+	if err != nil {
 		return false, "Cannot write k8s-yaml.conf: " + err.Error()
-        }
+	}
 
 	return true, ""
 }

--- a/pkg/deployment/updateHelm.go
+++ b/pkg/deployment/updateHelm.go
@@ -2,27 +2,27 @@ package deployment
 
 import (
 	"errors"
-        "github.com/thkukuk/kubic-control/pkg/tools"
+	"github.com/thkukuk/kubic-control/pkg/tools"
 )
 
 func checkHelmUpdate(chartName, releaseName, valuesPath, namespace, hash string) (bool, error) {
 	var success bool
 	var message string
-	if valuesPath == ""{
+	if valuesPath == "" {
 		success, message = tools.ExecuteCmd("helm", "template", releaseName,
 			chartName, "--kubeconfig=/etc/kubernetes/admin.conf",
 			"--namespace", namespace)
-	}else{
+	} else {
 		success, message = tools.ExecuteCmd("helm", "template", releaseName,
 			chartName, "--kubeconfig=/etc/kubernetes/admin.conf",
 			"-f", valuesPath,
 			"--namespace", namespace)
 	}
-	
+
 	if success != true {
 		return false, errors.New(message)
 	}
-	
+
 	newHash, _ := tools.Sha256sum_b(message)
 	if hash == newHash {
 		return false, nil
@@ -37,21 +37,20 @@ func UpdateHelm(chartName, releaseName, valuesPath, namespace string) error {
 	if namespace == "" {
 		namespace = "default"
 	}
-	if valuesPath == ""{
+	if valuesPath == "" {
 		success, message = tools.ExecuteCmd("helm", "upgrade", releaseName,
 			chartName, "--kubeconfig=/etc/kubernetes/admin.conf",
 			"--namespace", namespace)
-	}else{
+	} else {
 		success, message = tools.ExecuteCmd("helm", "upgrade", releaseName,
 			chartName, "--kubeconfig=/etc/kubernetes/admin.conf",
 			"-f", valuesPath,
 			"--namespace", namespace)
 	}
-	
+
 	if success != true {
 		return errors.New(message)
 	}
-
 
 	return setHelmConfig(chartName, releaseName, valuesPath, namespace)
 }

--- a/pkg/deployment/updateKustomize.go
+++ b/pkg/deployment/updateKustomize.go
@@ -17,47 +17,47 @@ package deployment
 import (
 	"os"
 
-        "gopkg.in/ini.v1"
-        "github.com/thkukuk/kubic-control/pkg/tools"
+	"github.com/thkukuk/kubic-control/pkg/tools"
+	"gopkg.in/ini.v1"
 )
 
 func UpdateKustomize(service string) (bool, string) {
 
 	retval, message := tools.ExecuteCmd("kustomize", "build",
-                StateDir + "/kustomize/" + service + "/overlay")
-        if retval != true {
-                return false, message
-        }
+		StateDir+"/kustomize/"+service+"/overlay")
+	if retval != true {
+		return false, message
+	}
 
-        f, err := os.Create(StateDir + "/kustomize/" + service + "/" + service + ".yaml")
-        if err != nil {
-                return false, err.Error()
-        }
-        defer f.Close()
-        _, err = f.WriteString(message)
-        if err != nil {
-                return false, err.Error()
-        }
-        f.Close()
+	f, err := os.Create(StateDir + "/kustomize/" + service + "/" + service + ".yaml")
+	if err != nil {
+		return false, err.Error()
+	}
+	defer f.Close()
+	_, err = f.WriteString(message)
+	if err != nil {
+		return false, err.Error()
+	}
+	f.Close()
 
-        retval, message = tools.ExecuteCmd("kubectl",
-                "--kubeconfig=/etc/kubernetes/admin.conf", "apply", "-f",
-                StateDir + "/kustomize/" + service + "/" + service + ".yaml")
-        if retval != true {
-                return false, message
-        }
+	retval, message = tools.ExecuteCmd("kubectl",
+		"--kubeconfig=/etc/kubernetes/admin.conf", "apply", "-f",
+		StateDir+"/kustomize/"+service+"/"+service+".yaml")
+	if retval != true {
+		return false, message
+	}
 
-        cfg, err := ini.LooseLoad(StateDir + "/k8s-kustomize.conf")
-        if err != nil {
-                return false, "Cannot load k8s-kustomize.conf: " + err.Error()
-        }
+	cfg, err := ini.LooseLoad(StateDir + "/k8s-kustomize.conf")
+	if err != nil {
+		return false, "Cannot load k8s-kustomize.conf: " + err.Error()
+	}
 
-	result, err := tools.Sha256sum_f(StateDir + "/kustomize/" + service + "/" + service + ".yaml");
-        cfg.Section("").Key(service).SetValue(result)
-        err = cfg.SaveTo(StateDir + "/k8s-kustomize.conf")
-        if err != nil {
-                return false, "Cannot write k8s-kustomize.conf: " + err.Error()
-        }
+	result, err := tools.Sha256sum_f(StateDir + "/kustomize/" + service + "/" + service + ".yaml")
+	cfg.Section("").Key(service).SetValue(result)
+	err = cfg.SaveTo(StateDir + "/k8s-kustomize.conf")
+	if err != nil {
+		return false, "Cannot write k8s-kustomize.conf: " + err.Error()
+	}
 
 	return true, ""
 }

--- a/pkg/kubeadm/destroyMaster.go
+++ b/pkg/kubeadm/destroyMaster.go
@@ -19,24 +19,23 @@ import (
 	"github.com/thkukuk/kubic-control/pkg/tools"
 )
 
-
 func DestroyMaster(in *pb.Empty, stream pb.Kubeadm_DestroyMasterServer) error {
-	success, message := ResetMaster ()
-        if success != true {
-                if err := stream.Send(&pb.StatusReply{Success: true, Message: message + " (ignored)"}); err != nil {
-                        return err
-                }
-                // ignore error
-        }
-        // Try some system cleanup, ignore if fails
-        tools.ExecuteCmd("/bin/sh", "-c", "sed -i -e 's|^REBOOT_METHOD=kured|REBOOT_METHOD=auto|g' /etc/transactional-update.conf")
-        success, message = tools.ExecuteCmd("/bin/sh", "-c", "iptables -F && iptables -t nat -F && iptables -t mangle -F && iptables -X")
-        if success != true {
-                if err := stream.Send(&pb.StatusReply{Success: true, Message: "Warning: removal of iptables failed."}); err != nil {
-                        return err
-                }
-        }
-        tools.ExecuteCmd("/bin/sh", "-c", "ip link delete cni0;  ip link delete flannel.1; ip link delete cilium_vxlan")
+	success, message := ResetMaster()
+	if success != true {
+		if err := stream.Send(&pb.StatusReply{Success: true, Message: message + " (ignored)"}); err != nil {
+			return err
+		}
+		// ignore error
+	}
+	// Try some system cleanup, ignore if fails
+	tools.ExecuteCmd("/bin/sh", "-c", "sed -i -e 's|^REBOOT_METHOD=kured|REBOOT_METHOD=auto|g' /etc/transactional-update.conf")
+	success, message = tools.ExecuteCmd("/bin/sh", "-c", "iptables -F && iptables -t nat -F && iptables -t mangle -F && iptables -X")
+	if success != true {
+		if err := stream.Send(&pb.StatusReply{Success: true, Message: "Warning: removal of iptables failed."}); err != nil {
+			return err
+		}
+	}
+	tools.ExecuteCmd("/bin/sh", "-c", "ip link delete cni0;  ip link delete flannel.1; ip link delete cilium_vxlan")
 
 	return nil
 }

--- a/pkg/kubeadm/rebootNode.go
+++ b/pkg/kubeadm/rebootNode.go
@@ -31,7 +31,7 @@ func RebootNode(nodeName string) (bool, string) {
 		return success, message
 	}
 
-	success, message = tools.ExecuteCmd("salt",  nodeName, "system.reboot")
+	success, message = tools.ExecuteCmd("salt", nodeName, "system.reboot")
 	if success != true {
 		return success, message
 	}

--- a/pkg/kubeadm/reset.go
+++ b/pkg/kubeadm/reset.go
@@ -15,30 +15,30 @@
 package kubeadm
 
 import (
-        "os"
+	"os"
 	"path/filepath"
 	"strings"
 
-        "github.com/thkukuk/kubic-control/pkg/tools"
+	"github.com/thkukuk/kubic-control/pkg/tools"
 )
 
 func removeContents(dir string) error {
-    files, err := filepath.Glob(filepath.Join(dir, "*"))
-    if err != nil {
-        return err
-    }
-    for _, file := range files {
-        err = os.RemoveAll(file)
-        if err != nil {
-            return err
-        }
-    }
-    return nil
+	files, err := filepath.Glob(filepath.Join(dir, "*"))
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		err = os.RemoveAll(file)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func ResetMaster() (bool, string) {
 
-	success, message :=  tools.ExecuteCmd("kubeadm", "reset", "--force")
+	success, message := tools.ExecuteCmd("kubeadm", "reset", "--force")
 
 	// cleanup behind kubeadm
 	removeContents("/var/lib/etcd")
@@ -62,74 +62,73 @@ func ResetNode(nodeName string, send OutputStream) (bool, string) {
 		return false, err.Error()
 	}
 
-	send(true, nodeName + ": draining node...")
+	send(true, nodeName+": draining node...")
 	/* ignore if we cannot drain node */
 	tools.DrainNode(hostname, "")
 
-	send(true, nodeName + ": verify etcd cluster...")
+	send(true, nodeName+": verify etcd cluster...")
 	/* Delete the node from the etcd member list if it is on it.
-             Else we will can end with a non-functional etcd cluster */
+	   Else we will can end with a non-functional etcd cluster */
 	success, message := tools.ExecuteCmd("etcdctl",
 		"--endpoints", "https://localhost:2379",
-		"--ca-file",  "/etc/kubernetes/pki/etcd/ca.crt",
+		"--ca-file", "/etc/kubernetes/pki/etcd/ca.crt",
 		"--cert-file", "/etc/kubernetes/pki/etcd/server.crt",
 		"--key-file", "/etc/kubernetes/pki/etcd/server.key",
 		"member", "list")
 	if success == true {
 		var etcd_member_id string
 
-		list := strings.Split (message, "\n")
-                for _, entry := range list {
-                        if strings.Contains(entry, "name=" + hostname) {
-				list := strings.Split (entry, ":");
+		list := strings.Split(message, "\n")
+		for _, entry := range list {
+			if strings.Contains(entry, "name="+hostname) {
+				list := strings.Split(entry, ":")
 				etcd_member_id = list[0]
 
 				success, message = tools.ExecuteCmd("etcdctl",
 					"--endpoints", "https://localhost:2379",
-					"--ca-file",  "/etc/kubernetes/pki/etcd/ca.crt",
+					"--ca-file", "/etc/kubernetes/pki/etcd/ca.crt",
 					"--cert-file", "/etc/kubernetes/pki/etcd/server.crt",
 					"--key-file", "/etc/kubernetes/pki/etcd/server.key",
 					"member", "remove", etcd_member_id)
 				if success != true {
-					send(success, nodeName + ": " + message + " (ignored)")
+					send(success, nodeName+": "+message+" (ignored)")
 					ret_success = false
 				}
-                        }
-                }
-        }
-
+			}
+		}
+	}
 
 	/* reset the node. Even if this fails, continue cleanup, but
-            report back */
-	send (true, nodeName + ": reset node...")
-	success, message = tools.ExecuteCmd("salt",  nodeName,
-		"cmd.run",  "kubeadm reset --force")
+	   report back */
+	send(true, nodeName+": reset node...")
+	success, message = tools.ExecuteCmd("salt", nodeName,
+		"cmd.run", "kubeadm reset --force")
 	if success != true {
-		send(success, nodeName + ": " + message + " (ignored)")
+		send(success, nodeName+": "+message+" (ignored)")
 		ret_success = false
 	}
 
-	send(true, nodeName + ": cleanup after kubeadm...")
+	send(true, nodeName+": cleanup after kubeadm...")
 	/* Try some system cleanup, ignore if fails */
-        tools.ExecuteCmd("salt", nodeName, "cmd.run",
+	tools.ExecuteCmd("salt", nodeName, "cmd.run",
 		"sed -i -e 's|^REBOOT_METHOD=kured|REBOOT_METHOD=auto|g' /etc/transactional-update.conf")
-        tools.ExecuteCmd("salt", nodeName, "grains.delkey",  "kubicd")
+	tools.ExecuteCmd("salt", nodeName, "grains.delkey", "kubicd")
 	tools.ExecuteCmd("salt", nodeName, "cmd.run",
 		"\"iptables -F && iptables -t nat -F && iptables -t mangle -F && iptables -X\"")
-        tools.ExecuteCmd("salt", nodeName, "cmd.run",  "\"rm -rf /var/lib/etcd/*\"")
-        tools.ExecuteCmd("salt", nodeName, "cmd.run",  "\"rm -rf /var/lib/cni/*\"")
-        tools.ExecuteCmd("salt", nodeName, "cmd.run",  "\"ip link delete cni0;  ip link delete flannel.1; ip link delete cilium_vxlan\"")
-        tools.ExecuteCmd("salt", nodeName, "service.disable",  "kubelet")
-	tools.ExecuteCmd("salt", nodeName, "service.stop",  "kubelet")
-        tools.ExecuteCmd("salt", nodeName, "service.disable",  "crio")
-        tools.ExecuteCmd("salt", nodeName, "service.stop",  "crio")
+	tools.ExecuteCmd("salt", nodeName, "cmd.run", "\"rm -rf /var/lib/etcd/*\"")
+	tools.ExecuteCmd("salt", nodeName, "cmd.run", "\"rm -rf /var/lib/cni/*\"")
+	tools.ExecuteCmd("salt", nodeName, "cmd.run", "\"ip link delete cni0;  ip link delete flannel.1; ip link delete cilium_vxlan\"")
+	tools.ExecuteCmd("salt", nodeName, "service.disable", "kubelet")
+	tools.ExecuteCmd("salt", nodeName, "service.stop", "kubelet")
+	tools.ExecuteCmd("salt", nodeName, "service.disable", "crio")
+	tools.ExecuteCmd("salt", nodeName, "service.stop", "crio")
 
 	/* ignore if we cannot delete the node*/
-	send(true, nodeName + ": final node deletion...")
+	send(true, nodeName+": final node deletion...")
 	success, message = tools.ExecuteCmd("kubectl", "--kubeconfig=/etc/kubernetes/admin.conf",
-		"delete",  "node",  hostname)
+		"delete", "node", hostname)
 	if success != true {
-		send(success, nodeName + ": " + message + " (ignored)")
+		send(success, nodeName+": "+message+" (ignored)")
 		ret_success = false
 	}
 

--- a/pkg/kubeadm/tools.go
+++ b/pkg/kubeadm/tools.go
@@ -19,13 +19,12 @@ import (
 )
 
 // read data /var/lib/kubic-control
-func Read_Cfg (file string, key string) string {
-        cfg, err := ini.LooseLoad("/var/lib/kubic-control/" + file)
-        if err != nil {
-                return ""
-        }
+func Read_Cfg(file string, key string) string {
+	cfg, err := ini.LooseLoad("/var/lib/kubic-control/" + file)
+	if err != nil {
+		return ""
+	}
 
-        value := cfg.Section("").Key(key).String()
+	value := cfg.Section("").Key(key).String()
 	return value
 }
-

--- a/pkg/kubicctl/addNode.go
+++ b/pkg/kubicctl/addNode.go
@@ -16,12 +16,12 @@ package kubicctl
 
 import (
 	"context"
-	"time"
 	"fmt"
 	"io"
 	"os"
+	"time"
 
-        log "github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	pb "github.com/thkukuk/kubic-control/api"
 )
@@ -31,11 +31,11 @@ var (
 )
 
 func AddNodeCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "add <node>",
-                Short: "Add new nodes to cluster",
-                Run: addNode,
-		Args: cobra.ExactArgs(1),
+	var subCmd = &cobra.Command{
+		Use:   "add <node>",
+		Short: "Add new nodes to cluster",
+		Run:   addNode,
+		Args:  cobra.ExactArgs(1),
 	}
 
 	subCmd.PersistentFlags().StringVar(&nodeType, "type", nodeType, "type of node, valid values are 'worker' or 'master'")
@@ -66,25 +66,25 @@ func addNode(cmd *cobra.Command, args []string) {
 	}
 
 	for {
-                r, err := stream.Recv()
-                if err == io.EOF {
-                        break
-                }
-                if err != nil {
-                        if r == nil {
-                                fmt.Fprintf(os.Stderr, "Adding node %s failed: %v\n", nodes, err)
-                        } else {
-                                fmt.Fprintf(os.Stderr, "Adding node %s failed: %s\n%v\n", r.Message, err)
-                        }
-                        os.Exit(1)
-                }
-                if (r.Success != true) {
-                        fmt.Fprintf(os.Stderr, "%s\n", r.Message)
-                        os.Exit(1)
-                } else {
-                        fmt.Printf("%s\n", r.Message)
-                }
-        }
+		r, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			if r == nil {
+				fmt.Fprintf(os.Stderr, "Adding node %s failed: %v\n", nodes, err)
+			} else {
+				fmt.Fprintf(os.Stderr, "Adding node %s failed: %s\n%v\n", r.Message, err)
+			}
+			os.Exit(1)
+		}
+		if r.Success != true {
+			fmt.Fprintf(os.Stderr, "%s\n", r.Message)
+			os.Exit(1)
+		} else {
+			fmt.Printf("%s\n", r.Message)
+		}
+	}
 
 	fmt.Print("Node(s) successfully added\n")
 }

--- a/pkg/kubicctl/certificates.go
+++ b/pkg/kubicctl/certificates.go
@@ -15,7 +15,7 @@
 package kubicctl
 
 import (
-        "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -23,18 +23,17 @@ var (
 )
 
 func CertificatesCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
+	var subCmd = &cobra.Command{
 		Use:   "certificates",
-                Short: "Manage certificates for kubicd/kubicctl communication",
-        }
+		Short: "Manage certificates for kubicd/kubicctl communication",
+	}
 
 	subCmd.PersistentFlags().StringVar(&PKI_dir, "pki-dir", PKI_dir, "PKI directory to find and store certificates")
 
-
-        subCmd.AddCommand(
+	subCmd.AddCommand(
 		CreateCertsCmd(),
-                InitializeCertsCmd(),
-        )
+		InitializeCertsCmd(),
+	)
 
-        return subCmd
+	return subCmd
 }

--- a/pkg/kubicctl/createCA.go
+++ b/pkg/kubicctl/createCA.go
@@ -14,8 +14,8 @@
 
 package kubicctl
 
-func CreateCA (pki_dir string) error {
-	err, _ := ExecuteCmd("certstrap", "--depot-path", pki_dir, "init",  "--common-name", "Kubic-Control-CA", "--passphrase", "")
+func CreateCA(pki_dir string) error {
+	err, _ := ExecuteCmd("certstrap", "--depot-path", pki_dir, "init", "--common-name", "Kubic-Control-CA", "--passphrase", "")
 
 	return err
 }

--- a/pkg/kubicctl/createCerts.go
+++ b/pkg/kubicctl/createCerts.go
@@ -16,68 +16,68 @@ package kubicctl
 
 import (
 	"context"
-        "time"
-        "fmt"
-	"os"
+	"fmt"
 	"io/ioutil"
+	"os"
+	"time"
 
-        "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 	pb "github.com/thkukuk/kubic-control/api"
 )
 
 func CreateCertsCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "create <user>",
-                Short: "Create certificate for an user",
-                Run: createCerts,
-                Args: cobra.ExactArgs(1),
-        }
+	var subCmd = &cobra.Command{
+		Use:   "create <user>",
+		Short: "Create certificate for an user",
+		Run:   createCerts,
+		Args:  cobra.ExactArgs(1),
+	}
 
-        return subCmd
+	return subCmd
 }
 
-func createCerts (cmd *cobra.Command, args []string) {
+func createCerts(cmd *cobra.Command, args []string) {
 	user := args[0]
 
 	// Set up a connection to the server.
-        conn, err := CreateConnection()
-        if err != nil {
-                return
-        }
-        defer conn.Close()
+	conn, err := CreateConnection()
+	if err != nil {
+		return
+	}
+	defer conn.Close()
 
-        c := pb.NewCertificateClient(conn)
+	c := pb.NewCertificateClient(conn)
 
-        ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-        defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
 
 	r, err := c.CreateCert(ctx, &pb.CreateCertRequest{Name: user})
-        if err != nil {
-                fmt.Fprintf(os.Stderr, "Could not initialize: %v\n", err)
-                os.Exit(1)
-        }
-        if r.Success {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not initialize: %v\n", err)
+		os.Exit(1)
+	}
+	if r.Success {
 		if len(r.Message) > 0 {
 			fmt.Printf(r.Message + "\n")
 		}
 
-		key :=[]byte(r.Key)
-		crt :=[]byte(r.Crt)
+		key := []byte(r.Key)
+		crt := []byte(r.Crt)
 
 		fmt.Printf("Writing %s.key...\n", user)
-		err := ioutil.WriteFile(user + ".key", key, 0600)
+		err := ioutil.WriteFile(user+".key", key, 0600)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error writing '%s.key': %v\n", user, err)
 			os.Exit(1)
 		}
 		fmt.Printf("Writing %s.crt...\n", user)
-		err = ioutil.WriteFile(user + ".crt", crt, 0600)
+		err = ioutil.WriteFile(user+".crt", crt, 0600)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error writing '%s.crt': %v\n", user, err)
 			os.Exit(1)
 		}
-        } else {
-                fmt.Fprintf(os.Stderr, "Couldn't create certificate for %s: %s\n", user, r.Message)
-                os.Exit(1)
-        }
+	} else {
+		fmt.Fprintf(os.Stderr, "Couldn't create certificate for %s: %s\n", user, r.Message)
+		os.Exit(1)
+	}
 }

--- a/pkg/kubicctl/createUser.go
+++ b/pkg/kubicctl/createUser.go
@@ -14,7 +14,7 @@
 
 package kubicctl
 
-func CreateUser (pki_dir string, cn string) error {
+func CreateUser(pki_dir string, cn string) error {
 	err, _ := ExecuteCmd("certstrap", "--depot-path", pki_dir, "request-cert",
 		"--common-name", cn, "--passphrase", "")
 

--- a/pkg/kubicctl/deploy.go
+++ b/pkg/kubicctl/deploy.go
@@ -19,9 +19,9 @@ import (
 )
 
 func DeployCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "deploy",
-                Short: "deploy new resource",
+	var subCmd = &cobra.Command{
+		Use:   "deploy",
+		Short: "deploy new resource",
 	}
 
 	subCmd.AddCommand(

--- a/pkg/kubicctl/deployHelloKubic.go
+++ b/pkg/kubicctl/deployHelloKubic.go
@@ -16,11 +16,11 @@ package kubicctl
 
 import (
 	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
 	"strings"
 	"time"
-	"fmt"
-	"os"
-	"io/ioutil"
 
 	"github.com/spf13/cobra"
 	pb "github.com/thkukuk/kubic-control/api"
@@ -28,15 +28,15 @@ import (
 
 var (
 	service_type = "NodePort"
-	arg_lbip = ""
+	arg_lbip     = ""
 )
 
 func DeployHelloKubicCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "hello-kubic",
-                Short: "Deploy hello-kubic",
-                Run: deployHelloKubic,
-		Args: cobra.ExactArgs(0),
+	var subCmd = &cobra.Command{
+		Use:   "hello-kubic",
+		Short: "Deploy hello-kubic",
+		Run:   deployHelloKubic,
+		Args:  cobra.ExactArgs(0),
 	}
 
 	subCmd.PersistentFlags().StringVarP(&service_type, "type", "t", service_type, "Type for this service: NodePort or LoadBalancer")
@@ -81,7 +81,7 @@ func deployHelloKubic(cmd *cobra.Command, args []string) {
 	}
 	if r.Success {
 		if len(output) > 0 && output != "stdout" {
-			message:=[]byte(r.Message)
+			message := []byte(r.Message)
 			err := ioutil.WriteFile(output, message, 0600)
 			if err != nil {
 				fmt.Fprintf(os.Stderr,

--- a/pkg/kubicctl/deployMetalLB.go
+++ b/pkg/kubicctl/deployMetalLB.go
@@ -16,21 +16,21 @@ package kubicctl
 
 import (
 	"context"
-	"time"
 	"fmt"
-	"os"
 	"io/ioutil"
+	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	pb "github.com/thkukuk/kubic-control/api"
 )
 
 func DeployMetalLBCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "metallb <ip range>",
-                Short: "Deploy MetalLB",
-                Run: deployMetalLB,
-		Args: cobra.ExactArgs(1),
+	var subCmd = &cobra.Command{
+		Use:   "metallb <ip range>",
+		Short: "Deploy MetalLB",
+		Run:   deployMetalLB,
+		Args:  cobra.ExactArgs(1),
 	}
 
 	return subCmd
@@ -60,7 +60,7 @@ func deployMetalLB(cmd *cobra.Command, args []string) {
 	}
 	if r.Success {
 		if len(output) > 0 && output != "stdout" {
-			message:=[]byte(r.Message)
+			message := []byte(r.Message)
 			err := ioutil.WriteFile(output, message, 0600)
 			if err != nil {
 				fmt.Fprintf(os.Stderr,

--- a/pkg/kubicctl/destroyCluster.go
+++ b/pkg/kubicctl/destroyCluster.go
@@ -16,21 +16,21 @@ package kubicctl
 
 import (
 	"context"
-	"time"
 	"fmt"
-	"os"
 	"io"
+	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	pb "github.com/thkukuk/kubic-control/api"
 )
 
 func DestroyClusterCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "destroy-cluster",
-                Short: "Destroy the whole cluster",
-                Run: destroyCluster,
-		Args: cobra.ExactArgs(0),
+	var subCmd = &cobra.Command{
+		Use:   "destroy-cluster",
+		Short: "Destroy the whole cluster",
+		Run:   destroyCluster,
+		Args:  cobra.ExactArgs(0),
 	}
 
 	return subCmd
@@ -57,24 +57,24 @@ func destroyCluster(cmd *cobra.Command, args []string) {
 	}
 
 	for {
-                r, err := stream.Recv()
-                if err == io.EOF {
-                        break
-                }
-                if err != nil {
-                        if r == nil {
-                                fmt.Fprintf(os.Stderr, "Removing all nodes failed: %v\n", err)
-                        } else {
-                                fmt.Fprintf(os.Stderr, "Removing node %s failed: %s\n%v\n", r.Message, err)
-                        }
+		r, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			if r == nil {
+				fmt.Fprintf(os.Stderr, "Removing all nodes failed: %v\n", err)
+			} else {
+				fmt.Fprintf(os.Stderr, "Removing node %s failed: %s\n%v\n", r.Message, err)
+			}
 			os.Exit(1)
-                }
-		if (r.Success != true) {
+		}
+		if r.Success != true {
 			fmt.Fprintf(os.Stderr, "%s\n", r.Message)
 		} else {
 			fmt.Printf("%s\n", r.Message)
 		}
-        }
+	}
 
 	fmt.Printf("All nodes removed, removing master...\n")
 
@@ -88,24 +88,24 @@ func destroyCluster(cmd *cobra.Command, args []string) {
 	}
 
 	for {
-                r, err := stream.Recv()
-                if err == io.EOF {
-                        break
-                }
-                if err != nil {
-                        if r == nil {
-                                fmt.Fprintf(os.Stderr, "Destroying master failed: %v\n", err)
-                        } else {
-                                fmt.Fprintf(os.Stderr, "Destroying master failed: %s\n%v\n", r.Message, err)
-                        }
+		r, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			if r == nil {
+				fmt.Fprintf(os.Stderr, "Destroying master failed: %v\n", err)
+			} else {
+				fmt.Fprintf(os.Stderr, "Destroying master failed: %s\n%v\n", r.Message, err)
+			}
 			os.Exit(1)
-                }
-		if (r.Success != true) {
+		}
+		if r.Success != true {
 			fmt.Fprintf(os.Stderr, "%s\n", r.Message)
 		} else {
 			fmt.Printf("%s\n", r.Message)
 		}
-        }
+	}
 
 	fmt.Printf("Kubernetes cluster completly removed!\n")
 }

--- a/pkg/kubicctl/executeCmd.go
+++ b/pkg/kubicctl/executeCmd.go
@@ -15,24 +15,24 @@
 package kubicctl
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
-	"fmt"
-	"bytes"
 )
 
-func ExecuteCmd(command string, arg ...string) (error,string) {
+func ExecuteCmd(command string, arg ...string) (error, string) {
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 
-        cmd := exec.Command(command, arg...)
+	cmd := exec.Command(command, arg...)
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 
 	//cmd.Print(cmd)
 
 	if err := cmd.Run(); err != nil {
-		fmt.Fprint(os.Stderr, "Error invoking " + command + ": " + fmt.Sprint(err) + "\n" + stderr.String() + "\n")
+		fmt.Fprint(os.Stderr, "Error invoking "+command+": "+fmt.Sprint(err)+"\n"+stderr.String()+"\n")
 		return err, "Error invoking " + command + ": " + err.Error()
 	} else {
 		fmt.Print(out.String())

--- a/pkg/kubicctl/fetchKubeconfig.go
+++ b/pkg/kubicctl/fetchKubeconfig.go
@@ -16,10 +16,10 @@ package kubicctl
 
 import (
 	"context"
-	"time"
 	"fmt"
-	"os"
 	"io/ioutil"
+	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	pb "github.com/thkukuk/kubic-control/api"
@@ -28,14 +28,14 @@ import (
 var output = ""
 
 func FetchKubeconfigCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "kubeconfig",
-                Short: "Download kubeconfig",
-                Run: fetchKubeconfig,
-		Args: cobra.ExactArgs(0),
+	var subCmd = &cobra.Command{
+		Use:   "kubeconfig",
+		Short: "Download kubeconfig",
+		Run:   fetchKubeconfig,
+		Args:  cobra.ExactArgs(0),
 	}
 
-        subCmd.PersistentFlags().StringVarP(&output, "output", "o",  "stdout", "File kubeconfig should be stored")
+	subCmd.PersistentFlags().StringVarP(&output, "output", "o", "stdout", "File kubeconfig should be stored")
 
 	return subCmd
 }
@@ -61,7 +61,7 @@ func fetchKubeconfig(cmd *cobra.Command, args []string) {
 	}
 	if r.Success {
 		if len(output) > 0 && output != "stdout" {
-			message:=[]byte(r.Message)
+			message := []byte(r.Message)
 			err := ioutil.WriteFile(output, message, 0600)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error writing '%s': %v\n", output, err)

--- a/pkg/kubicctl/getStatus.go
+++ b/pkg/kubicctl/getStatus.go
@@ -16,22 +16,22 @@ package kubicctl
 
 import (
 	"context"
-	"time"
 	"fmt"
 	"io"
 	"os"
+	"time"
 
-        log "github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	pb "github.com/thkukuk/kubic-control/api"
 )
 
 func GetStatusCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "status",
-                Short: "Status of current deployment",
-                Run: getStatus,
-		Args: cobra.ExactArgs(0),
+	var subCmd = &cobra.Command{
+		Use:   "status",
+		Short: "Status of current deployment",
+		Run:   getStatus,
+		Args:  cobra.ExactArgs(0),
 	}
 
 	return subCmd
@@ -58,18 +58,18 @@ func getStatus(cmd *cobra.Command, args []string) {
 
 	fmt.Printf("Kubicctl version %s\n", Version)
 	for {
-                r, err := stream.Recv()
-                if err == io.EOF {
-                        break
-                }
-                if err != nil {
-                        if r == nil {
-                                fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
-                        } else {
+		r, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			if r == nil {
+				fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+			} else {
 				fmt.Fprintf(os.Stderr, "ERROR: %s\n%v\n", r.Message, err)
 			}
-                        os.Exit(1)
-                }
+			os.Exit(1)
+		}
 		fmt.Printf("%s\n", r.Message)
-        }
+	}
 }

--- a/pkg/kubicctl/initMaster.go
+++ b/pkg/kubicctl/initMaster.go
@@ -16,39 +16,39 @@ package kubicctl
 
 import (
 	"context"
-	"time"
 	"fmt"
-	"os"
 	"io"
+	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	pb "github.com/thkukuk/kubic-control/api"
 )
 
 var (
-	podNetwork = "weave"
-	adv_addr = ""
+	podNetwork                = "weave"
+	adv_addr                  = ""
 	apiserver_cert_extra_sans = ""
-	multiMaster = ""
-	kubernetesVersion = ""
-	stage = ""
-	haproxy = ""
-	firstMaster = ""
+	multiMaster               = ""
+	kubernetesVersion         = ""
+	stage                     = ""
+	haproxy                   = ""
+	firstMaster               = ""
 )
 
 func InitMasterCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "init",
-                Short: "Initialize Kubernetes Master Node",
-                Run: initMaster,
-		Args: cobra.ExactArgs(0),
+	var subCmd = &cobra.Command{
+		Use:   "init",
+		Short: "Initialize Kubernetes Master Node",
+		Run:   initMaster,
+		Args:  cobra.ExactArgs(0),
 	}
 
-        subCmd.PersistentFlags().StringVar(&multiMaster, "multi-master", multiMaster, "Setup multimaster cluster, argument needs to be the DNS name of the load balancer")
-        subCmd.PersistentFlags().StringVar(&podNetwork, "pod-network", podNetwork, "pod network, valid values are 'cilium', 'flannel' or 'weave'")
-        subCmd.PersistentFlags().StringVar(&adv_addr, "adv-addr", adv_addr, "IP address the API Server will advertise it's listening on")
-        subCmd.PersistentFlags().StringVar(&apiserver_cert_extra_sans, "apiserver-cert-extra-sans", apiserver_cert_extra_sans, "additional IPs to add to the APIserver certificate")
-        subCmd.PersistentFlags().StringVar(&kubernetesVersion, "kubernetes-version", kubernetesVersion, "Kubernetes version of the control plane to deploy")
+	subCmd.PersistentFlags().StringVar(&multiMaster, "multi-master", multiMaster, "Setup multimaster cluster, argument needs to be the DNS name of the load balancer")
+	subCmd.PersistentFlags().StringVar(&podNetwork, "pod-network", podNetwork, "pod network, valid values are 'cilium', 'flannel', 'weave' or 'none'")
+	subCmd.PersistentFlags().StringVar(&adv_addr, "adv-addr", adv_addr, "IP address the API Server will advertise it's listening on")
+	subCmd.PersistentFlags().StringVar(&apiserver_cert_extra_sans, "apiserver-cert-extra-sans", apiserver_cert_extra_sans, "additional IPs to add to the APIserver certificate")
+	subCmd.PersistentFlags().StringVar(&kubernetesVersion, "kubernetes-version", kubernetesVersion, "Kubernetes version of the control plane to deploy")
 	subCmd.PersistentFlags().StringVar(&stage, "stage", stage, "Stage of development: 'official', 'devel'")
 	subCmd.PersistentFlags().StringVar(&haproxy, "haproxy", haproxy, "Name of salt minion running haproxy as loadbalancer")
 	subCmd.PersistentFlags().StringVar(&firstMaster, "salt", firstMaster, "Name of salt minion of first master")
@@ -70,7 +70,7 @@ func initMaster(cmd *cobra.Command, args []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
 
-	fmt.Print ("Initializing kubernetes master can take several minutes, please be patient.\n")
+	fmt.Print("Initializing kubernetes master can take several minutes, please be patient.\n")
 	stream, err := client.InitMaster(ctx, &pb.InitRequest{PodNetworking: podNetwork, AdvAddr: adv_addr, ApiserverCertExtraSans: apiserver_cert_extra_sans, MultiMaster: multiMaster, KubernetesVersion: kubernetesVersion, Stage: stage, Haproxy: haproxy, FirstMaster: firstMaster})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not initialize: %v\n", err)
@@ -83,13 +83,13 @@ func initMaster(cmd *cobra.Command, args []string) {
 		}
 		if err != nil {
 			if r == nil {
-				fmt.Fprintf(os.Stderr, "Creating Kubernetes master failed: %v\n",  err)
+				fmt.Fprintf(os.Stderr, "Creating Kubernetes master failed: %v\n", err)
 			} else {
 				fmt.Fprintf(os.Stderr, "Creating Kubernetes master failed: %s\n%v\n", r.Message, err)
 			}
 			os.Exit(1)
 		} else {
-			if (r.Success != true) {
+			if r.Success != true {
 				fmt.Fprintf(os.Stderr, "%s\n", r.Message)
 			} else {
 				fmt.Printf("%s\n", r.Message)

--- a/pkg/kubicctl/initializeCerts.go
+++ b/pkg/kubicctl/initializeCerts.go
@@ -15,24 +15,24 @@
 package kubicctl
 
 import (
-	"os"
 	"fmt"
+	"os"
 
-        "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 )
 
 func InitializeCertsCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "initialize",
-                Short: "Create CA, KubicD and admin certificates",
-                Run: initializeCerts,
-                Args: cobra.ExactArgs(0),
-        }
+	var subCmd = &cobra.Command{
+		Use:   "initialize",
+		Short: "Create CA, KubicD and admin certificates",
+		Run:   initializeCerts,
+		Args:  cobra.ExactArgs(0),
+	}
 
-        return subCmd
+	return subCmd
 }
 
-func initializeCerts (cmd *cobra.Command, args []string) {
+func initializeCerts(cmd *cobra.Command, args []string) {
 	err := CreateCA(PKI_dir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error creating CA: %v\n", err)

--- a/pkg/kubicctl/listNodes.go
+++ b/pkg/kubicctl/listNodes.go
@@ -16,20 +16,20 @@ package kubicctl
 
 import (
 	"context"
-	"time"
 	"fmt"
+	"time"
 
-        log "github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	pb "github.com/thkukuk/kubic-control/api"
 )
 
 func ListNodesCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "list",
-                Short: "List all reachable worker nodes",
-                Run: listNodes,
-		Args: cobra.ExactArgs(0),
+	var subCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List all reachable worker nodes",
+		Run:   listNodes,
+		Args:  cobra.ExactArgs(0),
 	}
 
 	return subCmd
@@ -61,7 +61,7 @@ func listNodes(cmd *cobra.Command, args []string) {
 			} else {
 				fmt.Print(", " + r.Node[i])
 			}
-                }
+		}
 		fmt.Print("\n")
 	} else {
 		log.Errorf("Getting list of nodes failed: %s", r.Message)

--- a/pkg/kubicctl/node.go
+++ b/pkg/kubicctl/node.go
@@ -19,23 +19,23 @@ import (
 )
 
 func DeployNodeCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "deploy",
-                Short: "Install new nodes with yomi",
-        }
+	var subCmd = &cobra.Command{
+		Use:   "deploy",
+		Short: "Install new nodes with yomi",
+	}
 
 	subCmd.AddCommand(
 		YomiPrepareConfigCmd(),
 		YomiInstallCmd(),
 	)
 
-        return subCmd
+	return subCmd
 }
 
 func NodeCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "node",
-                Short: "Manage kubernetes nodes",
+	var subCmd = &cobra.Command{
+		Use:   "node",
+		Short: "Manage kubernetes nodes",
 	}
 
 	subCmd.AddCommand(

--- a/pkg/kubicctl/rebootNode.go
+++ b/pkg/kubicctl/rebootNode.go
@@ -16,20 +16,20 @@ package kubicctl
 
 import (
 	"context"
-	"time"
 	"fmt"
+	"time"
 
-        log "github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	pb "github.com/thkukuk/kubic-control/api"
 )
 
 func RebootNodeCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "reboot <node>",
-                Short: "Reboot node",
-                Run: rebootNode,
-		Args: cobra.ExactArgs(1),
+	var subCmd = &cobra.Command{
+		Use:   "reboot <node>",
+		Short: "Reboot node",
+		Run:   rebootNode,
+		Args:  cobra.ExactArgs(1),
 	}
 
 	return subCmd

--- a/pkg/kubicctl/removeNode.go
+++ b/pkg/kubicctl/removeNode.go
@@ -16,21 +16,21 @@ package kubicctl
 
 import (
 	"context"
-	"time"
 	"fmt"
-	"os"
 	"io"
+	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	pb "github.com/thkukuk/kubic-control/api"
 )
 
 func RemoveNodeCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "remove <node>",
-                Short: "Remove node from cluster",
-                Run: removeNode,
-		Args: cobra.ExactArgs(1),
+	var subCmd = &cobra.Command{
+		Use:   "remove <node>",
+		Short: "Remove node from cluster",
+		Run:   removeNode,
+		Args:  cobra.ExactArgs(1),
 	}
 
 	return subCmd
@@ -59,24 +59,24 @@ func removeNode(cmd *cobra.Command, args []string) {
 	}
 
 	for {
-                r, err := stream.Recv()
-                if err == io.EOF {
-                        break
-                }
-                if err != nil {
-                        if r == nil {
-                                fmt.Fprintf(os.Stderr, "Removing node %s failed: %v\n", nodes, err)
-                        } else {
-                                fmt.Fprintf(os.Stderr, "Removing node %s failed: %s\n%v\n", r.Message, err)
-                        }
+		r, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			if r == nil {
+				fmt.Fprintf(os.Stderr, "Removing node %s failed: %v\n", nodes, err)
+			} else {
+				fmt.Fprintf(os.Stderr, "Removing node %s failed: %s\n%v\n", r.Message, err)
+			}
 			os.Exit(1)
-                }
-		if (r.Success != true) {
+		}
+		if r.Success != true {
 			fmt.Fprintf(os.Stderr, "%s\n", r.Message)
 		} else {
 			fmt.Printf("%s\n", r.Message)
 		}
-        }
+	}
 
 	fmt.Printf("Please make sure to reboot the Nodes before re-using them.\n")
 }

--- a/pkg/kubicctl/signUser.go
+++ b/pkg/kubicctl/signUser.go
@@ -14,7 +14,7 @@
 
 package kubicctl
 
-func SignUser (pki_dir string, cn string) error {
+func SignUser(pki_dir string, cn string) error {
 	err, _ := ExecuteCmd("certstrap", "--depot-path", pki_dir, "sign",
 		cn, "--CA", "Kubic-Control-CA")
 

--- a/pkg/kubicctl/upgradeKubernetes.go
+++ b/pkg/kubicctl/upgradeKubernetes.go
@@ -16,21 +16,21 @@ package kubicctl
 
 import (
 	"context"
-	"time"
 	"fmt"
-	"os"
 	"io"
+	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	pb "github.com/thkukuk/kubic-control/api"
 )
 
 func UpgradeKubernetesCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "upgrade",
-                Short: "Upgrade Kubernetes Cluster",
-                Run: upgradeKubernetes,
-		Args: cobra.ExactArgs(0),
+	var subCmd = &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade Kubernetes Cluster",
+		Run:   upgradeKubernetes,
+		Args:  cobra.ExactArgs(0),
 	}
 
 	subCmd.PersistentFlags().StringVar(&kubernetesVersion, "kubernetes-version", kubernetesVersion, "Kubernetes version of the control plane to deploy")
@@ -52,30 +52,30 @@ func upgradeKubernetes(cmd *cobra.Command, args []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
 
-	fmt.Print ("Upgrading kubernetes can take a very long time, please be patient.\n")
+	fmt.Print("Upgrading kubernetes can take a very long time, please be patient.\n")
 	stream, err := client.UpgradeKubernetes(ctx, &pb.UpgradeRequest{KubernetesVersion: kubernetesVersion})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not upgrade: %v", err)
 		os.Exit(1)
 	}
 	for {
-                r, err := stream.Recv()
-                if err == io.EOF {
-                        break
-                }
-                if err != nil  {
-                        if r == nil {
-                                fmt.Fprintf(os.Stderr, "Upgrading kubernetes failed: %v\n",  err)
-                        } else {
-                                fmt.Fprintf(os.Stderr, "Upgrading kubernetes failed: %s\n%v\n", r.Message, err)
-                        }
-                        os.Exit(1)
-                }
+		r, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			if r == nil {
+				fmt.Fprintf(os.Stderr, "Upgrading kubernetes failed: %v\n", err)
+			} else {
+				fmt.Fprintf(os.Stderr, "Upgrading kubernetes failed: %s\n%v\n", r.Message, err)
+			}
+			os.Exit(1)
+		}
 		if r.Success != true {
 			fmt.Fprintf(os.Stderr, "Upgrading kubernetes failed: %s\n", r.Message)
 			os.Exit(1)
 		} else {
 			fmt.Printf("%s\n", r.Message)
 		}
-        }
+	}
 }

--- a/pkg/kubicctl/yomiInstall.go
+++ b/pkg/kubicctl/yomiInstall.go
@@ -16,21 +16,21 @@ package kubicctl
 
 import (
 	"context"
-	"time"
 	"fmt"
-	"os"
 	"io"
+	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	pb "github.com/thkukuk/kubic-control/api"
 )
 
 func YomiInstallCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "install <name>",
-                Short: "Install a new node with yomi",
-                Run: install,
-		Args: cobra.ExactArgs(1),
+	var subCmd = &cobra.Command{
+		Use:   "install <name>",
+		Short: "Install a new node with yomi",
+		Run:   install,
+		Args:  cobra.ExactArgs(1),
 	}
 
 	return subCmd
@@ -60,26 +60,26 @@ func install(cmd *cobra.Command, args []string) {
 	}
 
 	for {
-                r, err := stream.Recv()
-                if err == io.EOF {
-                        break
-                }
-                if err != nil {
-                        if r == nil {
-                                fmt.Fprintf(os.Stderr, "Installing '%s' with yomi failed: %v\n",
+		r, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			if r == nil {
+				fmt.Fprintf(os.Stderr, "Installing '%s' with yomi failed: %v\n",
 					node, err)
-                        } else {
-                                fmt.Fprintf(os.Stderr, "Installing '%s' with yomi failed: %s\n%v\n",
+			} else {
+				fmt.Fprintf(os.Stderr, "Installing '%s' with yomi failed: %s\n%v\n",
 					node, r.Message, err)
-                        }
-			retval = 1;
-                } else {
-			if (r.Success != true) {
+			}
+			retval = 1
+		} else {
+			if r.Success != true {
 				fmt.Fprintf(os.Stderr, "%s\n", r.Message)
 			} else {
 				fmt.Printf("%s\n", r.Message)
 			}
 		}
-        }
+	}
 	os.Exit(retval)
 }

--- a/pkg/kubicctl/yomiPrepareConfig.go
+++ b/pkg/kubicctl/yomiPrepareConfig.go
@@ -16,33 +16,33 @@ package kubicctl
 
 import (
 	"context"
-	"time"
 	"fmt"
-	"os"
 	"io"
+	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	pb "github.com/thkukuk/kubic-control/api"
 )
 
 var (
-	arg_type string;
-	arg_efi bool;
-	arg_baremetal bool;
-	arg_disk string;
-	arg_repo string;
-	arg_repo_update string;
+	arg_type        string
+	arg_efi         bool
+	arg_baremetal   bool
+	arg_disk        string
+	arg_repo        string
+	arg_repo_update string
 )
 
 func YomiPrepareConfigCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "prepare <type> <name>",
-                Short: "Prepare yomi configuration for node of this type",
-                Run: prepareConfig,
-		Args: cobra.ExactArgs(2),
+	var subCmd = &cobra.Command{
+		Use:   "prepare <type> <name>",
+		Short: "Prepare yomi configuration for node of this type",
+		Run:   prepareConfig,
+		Args:  cobra.ExactArgs(2),
 	}
 
-        subCmd.PersistentFlags().StringVar(&arg_type, "type", "", "Type of node: haproxy, master, worker")
+	subCmd.PersistentFlags().StringVar(&arg_type, "type", "", "Type of node: haproxy, master, worker")
 	subCmd.PersistentFlags().StringVar(&arg_disk, "disk", "", "Disk device for installation")
 	subCmd.PersistentFlags().StringVar(&arg_repo, "repo", "", "Repository to install from")
 	subCmd.PersistentFlags().StringVar(&arg_repo_update, "update-repo", "", "Update repository to install from")
@@ -72,31 +72,31 @@ func prepareConfig(cmd *cobra.Command, args []string) {
 
 	// XXX efi and baremetal are missing
 	stream, err := client.PrepareConfig(ctx, &pb.PrepareConfigRequest{Saltnode: node, Type: nodeType,
-	Disk: arg_disk, Repo: arg_repo, RepoUpdate: arg_repo_update})
+		Disk: arg_disk, Repo: arg_repo, RepoUpdate: arg_repo_update})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not initialize: %v", err)
 		return
 	}
 
 	for {
-                r, err := stream.Recv()
-                if err == io.EOF {
-                        break
-                }
-                if err != nil {
-                        if r == nil {
-                                fmt.Fprintf(os.Stderr, "Create yomi configuration failed: %v\n", err)
-                        } else {
-                                fmt.Fprintf(os.Stderr, "Create yomi configuration failed: %s\n%v\n", r.Message, err)
-                        }
-			retval = 1;
-                } else {
-			if (r.Success != true) {
+		r, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			if r == nil {
+				fmt.Fprintf(os.Stderr, "Create yomi configuration failed: %v\n", err)
+			} else {
+				fmt.Fprintf(os.Stderr, "Create yomi configuration failed: %s\n%v\n", r.Message, err)
+			}
+			retval = 1
+		} else {
+			if r.Success != true {
 				fmt.Fprintf(os.Stderr, "%s\n", r.Message)
 			} else {
 				fmt.Printf("%s\n", r.Message)
 			}
 		}
-        }
+	}
 	os.Exit(retval)
 }

--- a/pkg/rbac/addAccount.go
+++ b/pkg/rbac/addAccount.go
@@ -15,32 +15,32 @@
 package rbac
 
 import (
-	"os"
 	"fmt"
+	"os"
 	"strings"
 
-        "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 	"gopkg.in/ini.v1"
 )
 
 func AddAccountCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "add <role> <user>",
-                Short: "Add user account to a role",
-                Run: addAccount,
-                Args: cobra.ExactArgs(2),
-        }
+	var subCmd = &cobra.Command{
+		Use:   "add <role> <user>",
+		Short: "Add user account to a role",
+		Run:   addAccount,
+		Args:  cobra.ExactArgs(2),
+	}
 
-        return subCmd
+	return subCmd
 }
 
-func addAccount (cmd *cobra.Command, args []string) {
+func addAccount(cmd *cobra.Command, args []string) {
 	role := args[0]
 	user := args[1]
 	entry := ""
 
 	cfg, err := ini.LooseLoad("/usr/etc/kubicd/rbac.conf", "/etc/kubicd/rbac.conf")
-        if err != nil {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "Cannot load rbac.conf: %v\n", err)
 		os.Exit(1)
 	}
@@ -51,12 +51,12 @@ func addAccount (cmd *cobra.Command, args []string) {
 		entry = cfg.Section("").Key(role).String()
 	}
 	userList := strings.Split(entry, ",")
-        for i := range userList {
-                if user == strings.TrimSpace(userList[i]) {
+	for i := range userList {
+		if user == strings.TrimSpace(userList[i]) {
 			fmt.Printf("User already part of '%s'\n", role)
-                        return
-                }
-        }
+			return
+		}
+	}
 	if len(entry) > 0 {
 		entry = entry + "," + user
 	} else {
@@ -72,6 +72,6 @@ func addAccount (cmd *cobra.Command, args []string) {
 	werr = wcfg.SaveTo("/etc/kubicd/rbac.conf")
 	if werr != nil {
 		fmt.Fprintf(os.Stderr, "Writing rbac.conf failed: %v\n", werr)
-		os.Exit (1)
+		os.Exit(1)
 	}
 }

--- a/pkg/rbac/listRoles.go
+++ b/pkg/rbac/listRoles.go
@@ -15,27 +15,27 @@
 package rbac
 
 import (
-	"os"
 	"fmt"
+	"os"
 
-        "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 	"gopkg.in/ini.v1"
 )
 
 func ListRolesCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
-                Use:   "list",
-                Short: "List roles and accounts",
-                Run: listRoles,
-                Args: cobra.ExactArgs(0),
-        }
+	var subCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List roles and accounts",
+		Run:   listRoles,
+		Args:  cobra.ExactArgs(0),
+	}
 
-        return subCmd
+	return subCmd
 }
 
-func listRoles (cmd *cobra.Command, args []string) {
+func listRoles(cmd *cobra.Command, args []string) {
 	cfg, err := ini.LooseLoad("/usr/etc/kubicd/rbac.conf", "/etc/kubicd/rbac.conf")
-        if err != nil {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "Cannot load rbac.conf: %v\n", err)
 		os.Exit(1)
 	}

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -15,20 +15,20 @@
 package rbac
 
 import (
-        "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 )
 
 func RBACCmd() *cobra.Command {
-        var subCmd = &cobra.Command {
+	var subCmd = &cobra.Command{
 		Use:   "rbac",
-                Short: "Manage RBAC rules",
-        }
+		Short: "Manage RBAC rules",
+	}
 
-        subCmd.AddCommand(
+	subCmd.AddCommand(
 		AddAccountCmd(),
-//                RemoveAccountCmd(),
+		//                RemoveAccountCmd(),
 		ListRolesCmd(),
-        )
+	)
 
-        return subCmd
+	return subCmd
 }

--- a/pkg/tools/drainNode.go
+++ b/pkg/tools/drainNode.go
@@ -14,7 +14,7 @@
 
 package tools
 
-func DrainNode(hostname string, timeout string) (bool,string) {
+func DrainNode(hostname string, timeout string) (bool, string) {
 
 	var arg_timeout string
 
@@ -25,6 +25,6 @@ func DrainNode(hostname string, timeout string) (bool,string) {
 	}
 
 	return ExecuteCmd("kubectl", "--kubeconfig=/etc/kubernetes/admin.conf",
-		"drain",  hostname, "--timeout", arg_timeout, "--delete-local-data",
-		"--force",  "--ignore-daemonsets")
+		"drain", hostname, "--timeout", arg_timeout, "--delete-local-data",
+		"--force", "--ignore-daemonsets")
 }

--- a/pkg/tools/executeCmd.go
+++ b/pkg/tools/executeCmd.go
@@ -15,30 +15,30 @@
 package tools
 
 import (
-	"os/exec"
-	"fmt"
 	"bytes"
+	"fmt"
+	"os/exec"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
 
-func ExecuteCmd(command string, arg ...string) (bool,string) {
+func ExecuteCmd(command string, arg ...string) (bool, string) {
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 
-        cmd := exec.Command(command, arg...)
+	cmd := exec.Command(command, arg...)
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 
 	log.Infof("Executing %s: %v", cmd.Path, cmd.Args)
 
 	if err := cmd.Run(); err != nil {
-		if (command == "salt") {
+		if command == "salt" {
 			stderr = out // salt is evil, errors are written to stdout
 		}
 		log.Error("Error invoking " + command + ": " + fmt.Sprint(err) + "\n" + stderr.String())
-		if (command == "salt") {
+		if command == "salt" {
 			return false, "Error invoking " + command + ": " + err.Error() + "\n(" + strings.TrimSuffix(stderr.String(), "\n") + ")"
 		} else {
 			return false, "Error invoking " + command + ": " + err.Error()

--- a/pkg/tools/exists.go
+++ b/pkg/tools/exists.go
@@ -20,8 +20,12 @@ import (
 
 // Exists returns whether the given file or directory exists
 func Exists(path string) (bool, error) {
-    _, err := os.Stat(path)
-    if err == nil { return true, nil }
-    if os.IsNotExist(err) { return false, nil }
-    return true, err
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return true, err
 }

--- a/pkg/tools/getKubeadmVersion.go
+++ b/pkg/tools/getKubeadmVersion.go
@@ -18,17 +18,17 @@ import (
 	"strings"
 )
 
-func GetKubeadmVersion(salt string) (bool,string) {
+func GetKubeadmVersion(salt string) (bool, string) {
 	// find out our kubeadm version and use that to upgrade to this version
 	var success bool
 	var message string
 	if len(salt) > 0 {
 		success, message = ExecuteCmd("salt", "--out=txt", salt, "cmd.run", "rpm -q --qf '%{VERSION}' kubernetes-kubeadm")
-		message = strings.Replace(message, "\n","",-1)
-		i := strings.Index(message, ":")+1
+		message = strings.Replace(message, "\n", "", -1)
+		i := strings.Index(message, ":") + 1
 		message = strings.TrimSpace(message[i:])
 	} else {
-		success, message = ExecuteCmd("rpm", "-q", "--qf", "'%{VERSION}'",  "kubernetes-kubeadm")
+		success, message = ExecuteCmd("rpm", "-q", "--qf", "'%{VERSION}'", "kubernetes-kubeadm")
 	}
 	if success != true {
 		return false, message

--- a/pkg/tools/getListOfNodes.go
+++ b/pkg/tools/getListOfNodes.go
@@ -25,12 +25,12 @@ func GetListOfNodes(role string) (bool, string, []string) {
 	}
 
 	// Get list of all nodes of this role
-        success, message := ExecuteCmd("salt", "-G", "kubicd:kubic-" + role + "-node", "grains.get",  "kubic-" + role + "-node")
-        if success != true {
+	success, message := ExecuteCmd("salt", "-G", "kubicd:kubic-"+role+"-node", "grains.get", "kubic-"+role+"-node")
+	if success != true {
 		return success, message, nil
-        }
-        message = strings.TrimSuffix(message, "\n")
-        nodelist := strings.Split (strings.Replace(message, ":", "", -1), "\n")
+	}
+	message = strings.TrimSuffix(message, "\n")
+	nodelist := strings.Split(strings.Replace(message, ":", "", -1), "\n")
 
 	return true, "", nodelist
 }

--- a/pkg/tools/getNodeName.go
+++ b/pkg/tools/getNodeName.go
@@ -22,13 +22,13 @@ import (
 func GetNodeName(target string) (string, error) {
 
 	// salt host names are not identical with kubernetes node name.
-        // Output of hostname should be identical to node name
-        success, message := ExecuteCmd("salt",  target, "network.get_hostname")
-        if success != true {
-                return target, errors.New(message)
-        }
-        hostname := strings.Replace(message, "\n","",-1)
-        i := strings.Index(hostname,":")+1
-        hostname = hostname[i:]
-	return strings.TrimSpace(hostname),nil
+	// Output of hostname should be identical to node name
+	success, message := ExecuteCmd("salt", target, "network.get_hostname")
+	if success != true {
+		return target, errors.New(message)
+	}
+	hostname := strings.Replace(message, "\n", "", -1)
+	i := strings.Index(hostname, ":") + 1
+	hostname = hostname[i:]
+	return strings.TrimSpace(hostname), nil
 }

--- a/pkg/tools/sha256sum.go
+++ b/pkg/tools/sha256sum.go
@@ -15,10 +15,10 @@
 package tools
 
 import (
-	"os"
-	"io"
-	"encoding/hex"
 	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
 )
 
 func Sha256sum_b(buffer string) (result string, err error) {
@@ -29,18 +29,18 @@ func Sha256sum_b(buffer string) (result string, err error) {
 }
 
 func Sha256sum_f(filePath string) (result string, err error) {
-    file, err := os.Open(filePath)
-    if err != nil {
-        return "", err
-    }
-    defer file.Close()
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
 
-    hash := sha256.New()
-    _, err = io.Copy(hash, file)
-    if err != nil {
-        return "", err
-    }
+	hash := sha256.New()
+	_, err = io.Copy(hash, file)
+	if err != nil {
+		return "", err
+	}
 
-    result = hex.EncodeToString(hash.Sum(nil))
-    return result, nil
+	result = hex.EncodeToString(hash.Sum(nil))
+	return result, nil
 }

--- a/pkg/yomi/Salt2PillarName.go
+++ b/pkg/yomi/Salt2PillarName.go
@@ -20,7 +20,7 @@ import (
 
 func Salt2PillarName(name string) string {
 	// Replace all '.' with '_'
-	temp := strings.Replace(name, ".","_",-1)
+	temp := strings.Replace(name, ".", "_", -1)
 	// Replace all spaces with '-'
-	return strings.Replace(temp, " ","-",-1)
+	return strings.Replace(temp, " ", "-", -1)
 }

--- a/pkg/yomi/prepareConfig.go
+++ b/pkg/yomi/prepareConfig.go
@@ -15,12 +15,12 @@
 package yomi
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"os"
 	"os/user"
-	"io/ioutil"
-	"strings"
 	"strconv"
-	"encoding/json"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	pb "github.com/thkukuk/kubic-control/api"
@@ -28,61 +28,60 @@ import (
 )
 
 func set_perm(path string) error {
-        err := os.Chmod(path, 0640)
-        if err != nil {
-                return err
-        }
+	err := os.Chmod(path, 0640)
+	if err != nil {
+		return err
+	}
 
-        if os.Getuid() != 0 {
-                // don't change ownership if we are not root
-                return nil
-        }
+	if os.Getuid() != 0 {
+		// don't change ownership if we are not root
+		return nil
+	}
 
-        gr, err := user.LookupGroup("salt")
-        if err != nil {
-                // XXX if we don't have the group, do nothing
-                return nil
-        }
+	gr, err := user.LookupGroup("salt")
+	if err != nil {
+		// XXX if we don't have the group, do nothing
+		return nil
+	}
 
-        gid, err := strconv.Atoi(gr.Gid)
-        if err != nil {
-                return err
-        }
-        return os.Chown(path, 0, gid)
+	gid, err := strconv.Atoi(gr.Gid)
+	if err != nil {
+		return err
+	}
+	return os.Chown(path, 0, gid)
 }
-
 
 func PrepareConfig(in *pb.PrepareConfigRequest, stream pb.Yomi_PrepareConfigServer) error {
 
 	if err := stream.Send(&pb.StatusReply{Success: true,
 		Message: "Prepare salt configuration for Node " + in.Saltnode + " as " + in.Type}); err != nil {
-			return err
-		}
+		return err
+	}
 
 	if in.Type != "haproxy" {
 		if err := stream.Send(&pb.StatusReply{Success: false,
 			Message: "Invalid type '" + in.Type + "', valid types are: \"haproxy\""}); err != nil {
-				return err
-			}
+			return err
+		}
 		return nil
 	}
 
 	// Get the hardware information from the new node
 
 	if err := stream.Send(&pb.StatusReply{Success: true,
-		Message: "Gather hardware informations for Node " + in.Saltnode }); err != nil {
-			return err
-		}
+		Message: "Gather hardware informations for Node " + in.Saltnode}); err != nil {
+		return err
+	}
 
 	// make sure latest modules are used on minion
-        success, message := tools.ExecuteCmd("salt", in.Saltnode, "saltutil.sync_all")
-        if success != true {
-                if err := stream.Send(&pb.StatusReply{Success: false,
-                        Message: message}); err != nil {
-                                return err
-                        }
-                return nil
-        }
+	success, message := tools.ExecuteCmd("salt", in.Saltnode, "saltutil.sync_all")
+	if success != true {
+		if err := stream.Send(&pb.StatusReply{Success: false,
+			Message: message}); err != nil {
+			return err
+		}
+		return nil
+	}
 
 	pillarName := Salt2PillarName(in.Saltnode)
 	pillarFile := "/srv/pillar/kubicd/" + pillarName + ".sls"
@@ -91,12 +90,12 @@ func PrepareConfig(in *pb.PrepareConfigRequest, stream pb.Yomi_PrepareConfigServ
 	if err != nil {
 		if err2 := stream.Send(&pb.StatusReply{Success: false,
 			Message: "Could not create \"" + pillarFile + "\": " + err.Error()}); err2 != nil {
-				return err2
-			}
+			return err2
+		}
 		return nil
 	}
 
-	_, err = f.WriteString( "# Meta pillar for Yomi\n" +
+	_, err = f.WriteString("# Meta pillar for Yomi\n" +
 		"#\n" +
 		"# There are some parameters that can be configured and adapted to\n" +
 		"# launch a basic Yomi installation:\n" +
@@ -110,8 +109,8 @@ func PrepareConfig(in *pb.PrepareConfigRequest, stream pb.Yomi_PrepareConfigServ
 	if err != nil {
 		if err2 := stream.Send(&pb.StatusReply{Success: false,
 			Message: "Writing to \"" + pillarFile + "\" failed: " + err.Error()}); err2 != nil {
-				return err2
-			}
+			return err2
+		}
 		return nil
 	}
 
@@ -123,14 +122,14 @@ func PrepareConfig(in *pb.PrepareConfigRequest, stream pb.Yomi_PrepareConfigServ
 		if success != true {
 			if err := stream.Send(&pb.StatusReply{Success: false,
 				Message: message}); err != nil {
-					return err
-				}
+				return err
+			}
 			return nil
 		}
-		uefi := strings.Replace(message, "\n","",-1)
-		i := strings.Index(uefi,":")+1
+		uefi := strings.Replace(message, "\n", "", -1)
+		i := strings.Index(uefi, ":") + 1
 		uefi = strings.TrimSpace(uefi[i:])
-		log.Info ("UEFI: " + uefi)
+		log.Info("UEFI: " + uefi)
 		if strings.EqualFold(uefi, "true") {
 			useEfi = true
 		}
@@ -147,8 +146,8 @@ func PrepareConfig(in *pb.PrepareConfigRequest, stream pb.Yomi_PrepareConfigServ
 	if err != nil {
 		if err2 := stream.Send(&pb.StatusReply{Success: false,
 			Message: "Writing to \"" + pillarFile + "\" failed: " + err.Error()}); err2 != nil {
-				return err2
-			}
+			return err2
+		}
 		return nil
 	}
 
@@ -159,14 +158,14 @@ func PrepareConfig(in *pb.PrepareConfigRequest, stream pb.Yomi_PrepareConfigServ
 		if success != true {
 			if err := stream.Send(&pb.StatusReply{Success: false,
 				Message: message}); err != nil {
-					return err
-				}
+				return err
+			}
 			return nil
 		}
-		virtualisation := strings.Replace(message, "\n","",-1)
-		i := strings.Index(virtualisation,":")+1
+		virtualisation := strings.Replace(message, "\n", "", -1)
+		i := strings.Index(virtualisation, ":") + 1
 		virtualisation = strings.TrimSpace(virtualisation[i:])
-		log.Info ("Virtualisation: " + virtualisation)
+		log.Info("Virtualisation: " + virtualisation)
 		if strings.EqualFold(virtualisation, "none") {
 			useBareMetal = true
 		}
@@ -183,8 +182,8 @@ func PrepareConfig(in *pb.PrepareConfigRequest, stream pb.Yomi_PrepareConfigServ
 	if err != nil {
 		if err2 := stream.Send(&pb.StatusReply{Success: false,
 			Message: "Writing to \"" + pillarFile + "\" failed: " + err.Error()}); err2 != nil {
-				return err2
-			}
+			return err2
+		}
 		return nil
 	}
 
@@ -196,8 +195,8 @@ func PrepareConfig(in *pb.PrepareConfigRequest, stream pb.Yomi_PrepareConfigServ
 		if success != true {
 			if err := stream.Send(&pb.StatusReply{Success: false,
 				Message: message}); err != nil {
-					return err
-				}
+				return err
+			}
 			return nil
 		}
 		var hwinfo_all map[string]interface{}
@@ -205,22 +204,22 @@ func PrepareConfig(in *pb.PrepareConfigRequest, stream pb.Yomi_PrepareConfigServ
 		if err != nil {
 			if err2 := stream.Send(&pb.StatusReply{Success: false,
 				Message: "Detecting disks failed: " + err.Error()}); err2 != nil {
-					return err2
-				}
+				return err2
+			}
 			return nil
 		}
 		hwinfo_node := hwinfo_all[in.Saltnode].(map[string]interface{})
 		hwinfo := hwinfo_node["hwinfo"].(map[string]interface{})
 		hwinfo_disk := hwinfo["disk"].(map[string]interface{})
-		if len (hwinfo_disk) != 1 {
+		if len(hwinfo_disk) != 1 {
 			message = "Found more than one disk:\n"
 			for key, value := range hwinfo_disk {
-				message = message + "- " + key + " (" + value.(string) +")\n"
+				message = message + "- " + key + " (" + value.(string) + ")\n"
 			}
 			if err := stream.Send(&pb.StatusReply{Success: false,
 				Message: message}); err != nil {
-					return err
-				}
+				return err
+			}
 			return nil
 		}
 
@@ -242,89 +241,89 @@ func PrepareConfig(in *pb.PrepareConfigRequest, stream pb.Yomi_PrepareConfigServ
 	if err != nil {
 		if err2 := stream.Send(&pb.StatusReply{Success: false,
 			Message: "Writing to \"" + pillarFile + "\" failed: " + err.Error()}); err2 != nil {
-				return err2
-			}
+			return err2
+		}
 		return nil
 	}
 
 	if err := f.Close(); err != nil {
 		if err2 := stream.Send(&pb.StatusReply{Success: false,
 			Message: "Closing \"" + pillarFile + "\" failed: " + err.Error()}); err2 != nil {
-				return err2
-			}
+			return err2
+		}
 		return nil
 	}
 
-	set_perm (pillarFile)
+	set_perm(pillarFile)
 
 	// Create top.sls if it does not exist, else add our entry
 	found, _ := tools.Exists("/srv/pillar/top.sls")
 	if !found {
-                f, err := os.Create("/srv/pillar/top.sls")
-                if err != nil {
-                        message = "Could not create \"/srv/pillar/top.sls\": " + err.Error()
+		f, err := os.Create("/srv/pillar/top.sls")
+		if err != nil {
+			message = "Could not create \"/srv/pillar/top.sls\": " + err.Error()
 			if err2 := stream.Send(&pb.StatusReply{Success: false,
 				Message: message}); err2 != nil {
-					return err2
-				}
+				return err2
+			}
 			return nil
-                }
+		}
 
-                _, err = f.WriteString("base:\n" +
+		_, err = f.WriteString("base:\n" +
 			"  " + in.Saltnode + ":\n" +
 			"    - kubicd/" + pillarName + "\n" +
-                        "\n")
-                if err := f.Close(); err != nil {
-                        message = "Closing \"/srv/pillar/top.sls\" failed: " + err.Error()
+			"\n")
+		if err := f.Close(); err != nil {
+			message = "Closing \"/srv/pillar/top.sls\" failed: " + err.Error()
 			if err2 := stream.Send(&pb.StatusReply{Success: false,
 				Message: message}); err2 != nil {
-					return err2
-				}
+				return err2
+			}
 			return nil
-                }
+		}
 	} else {
 		// File exists,
 
 		data, err := ioutil.ReadFile("/srv/pillar/top.sls")
-                if err != nil {
-                        message = "Error reading \"/srv/pillar/top.sls\": " + err.Error()
+		if err != nil {
+			message = "Error reading \"/srv/pillar/top.sls\": " + err.Error()
 			if err2 := stream.Send(&pb.StatusReply{Success: false,
 				Message: message}); err2 != nil {
-					return err2
-				}
+				return err2
+			}
 			return nil
-                }
-                file := string(data)
-                // Remove trailing \n to avoid additional new line
-                file = strings.TrimSuffix(file, "\n")
-                /* func Split(s, sep string) []string */
-                temp := strings.Split(file, "\n")
+		}
+		file := string(data)
+		// Remove trailing \n to avoid additional new line
+		file = strings.TrimSuffix(file, "\n")
+		/* func Split(s, sep string) []string */
+		temp := strings.Split(file, "\n")
 
 		var newContent []string
-                found_node := false
+		found_node := false
 		found_pillar := false
 		write_pillar := false
-                for _, item := range temp {
+		for _, item := range temp {
 			if found_node {
 				if strings.Contains(item, "    -") {
-					if strings.Contains(item, "kubicd/" + pillarName) {
+					if strings.Contains(item, "kubicd/"+pillarName) {
 						found_node = false
 						found_pillar = true
 					}
 				} else {
-					newContent = append (newContent, "    - kubicd/" + pillarName)
+					newContent = append(newContent, "    - kubicd/"+pillarName)
 					write_pillar = true
 				}
 			}
-			if strings.Contains(item, in.Saltnode + ":") {
+			if strings.Contains(item, in.Saltnode+":") {
 				found_node = true
 			}
-			newContent = append (newContent, item)
+			newContent = append(newContent, item)
 		}
 
 		if !found_pillar && !write_pillar {
-			newContent = append (newContent, "  " + in.Saltnode + ":")
-			newContent = append (newContent, "    - kubicd/" + pillarName)
+			newContent = append(newContent, "  "+in.Saltnode+":")
+			newContent = append(newContent, "    - kubicd/"+pillarName)
 			write_pillar = true
 		}
 		if write_pillar {
@@ -335,8 +334,8 @@ func PrepareConfig(in *pb.PrepareConfigRequest, stream pb.Yomi_PrepareConfigServ
 				message = "Could not create \"/srv/pillar/top.sls\": " + err.Error()
 				if err2 := stream.Send(&pb.StatusReply{Success: false,
 					Message: message}); err2 != nil {
-						return err2
-					}
+					return err2
+				}
 				return nil
 			}
 
@@ -346,8 +345,8 @@ func PrepareConfig(in *pb.PrepareConfigRequest, stream pb.Yomi_PrepareConfigServ
 					message = "Writing to \"/srv/pillar/top.sls\" failed: " + err.Error()
 					if err2 := stream.Send(&pb.StatusReply{Success: false,
 						Message: message}); err2 != nil {
-							return err2
-						}
+						return err2
+					}
 					return nil
 				}
 
@@ -356,8 +355,8 @@ func PrepareConfig(in *pb.PrepareConfigRequest, stream pb.Yomi_PrepareConfigServ
 				message = "Closing \"/srv/pillar/top.sls\" failed: " + err.Error()
 				if err2 := stream.Send(&pb.StatusReply{Success: false,
 					Message: message}); err2 != nil {
-						return err2
-					}
+					return err2
+				}
 				return nil
 			}
 			set_perm("/srv/pillar/top.sls")
@@ -366,7 +365,7 @@ func PrepareConfig(in *pb.PrepareConfigRequest, stream pb.Yomi_PrepareConfigServ
 
 	if err := stream.Send(&pb.StatusReply{Success: true,
 		Message: "Configuration created. Please check \"" + pillarFile + "\" and run install phase."}); err != nil {
-			return err
-		}
+		return err
+	}
 	return nil
 }


### PR DESCRIPTION
A few times I wanted to use kubic for it's CRI-O and etcd integration with a CNI that was not flannel, cilium, weavenet or an upstream version of these CNI.

I did not wanted to make a request for a feature so I tried to add it myself. It was tested on single and multi-master setups.

On my first commit I had a few junk modifications done by an automatic gofmt. I ran it on all the code (it's on a separate commit so it can be undone easily).

I also updated the README to mention the posibility.