### PR TITLE
Fix typo in upgrade Kubernetes upgrade node

### DIFF
--- a/pkg/kubeadm/upgradeKubernetes.go
+++ b/pkg/kubeadm/upgradeKubernetes.go
@@ -140,7 +140,7 @@ func upgradeNodes(in *pb.UpgradeRequest,
 			tools.DrainNode(hostname, "")
 
 			success, message = tools.ExecuteCmd("salt", nodelist[i], "cmd.run",
-				"\"kubeadm upgrade node")
+				"\"kubeadm upgrade node\"")
 			if success != true {
 				failedNodes = failedNodes + nodelist[i] + " (kubeadm), "
 			} else {


### PR DESCRIPTION
During https://github.com/thkukuk/kubic-control/commit/e5cc3ddba8eb0a15412f1f7854632f8353d46381, the final double quote was accidentally removed, causing the script to fail to upgrade.

With this change, I've managed to successfully upgrade a cluster consisting of 3 worker nodes and 3 masters from Kubernetes `1.21.4` to `1.22.1`.

Congratulations for this tool, it is really great and useful!

