### PR TITLE
removed "--module-executors='[direct_call]'"

### DIFF
--- a/pkg/kubeadm/addNode.go
+++ b/pkg/kubeadm/addNode.go
@@ -89,10 +89,10 @@ func AddNode(in *pb.AddNodeRequest, stream pb.Kubeadm_AddNodeServer) error {
 
 	// Differentiate between 'name1,name2' and 'name[1,2]'
 	if strings.Index(nodeNames, ",") >= 0 && strings.Index(nodeNames, "[") == -1 {
-		success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", "--out=txt",
+		success, message = tools.ExecuteCmd("salt",  "--out=txt",
 			"-L", nodeNames, "test.ping")
 	} else {
-		success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", "--out=txt",
+		success, message = tools.ExecuteCmd("salt",  "--out=txt",
 			nodeNames, "test.ping")
 	}
 	if success != true {
@@ -121,7 +121,7 @@ func AddNode(in *pb.AddNodeRequest, stream pb.Kubeadm_AddNodeServer) error {
 
 			stream.Send(&pb.StatusReply{Success: true, Message: nodelist[i] + ": adding node..."})
 
-			success, message := tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodelist[i], "service.start", "crio")
+			success, message := tools.ExecuteCmd("salt",  nodelist[i], "service.start", "crio")
 			if success != true {
 				if err := stream.Send(&pb.StatusReply{Success: false, Message: nodelist[i] + ": " + message}); err != nil {
 					log.Errorf("Send message failed: %s", err)
@@ -129,7 +129,7 @@ func AddNode(in *pb.AddNodeRequest, stream pb.Kubeadm_AddNodeServer) error {
 				failed++
 				return
 			}
-			success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodelist[i], "service.enable", "crio")
+			success, message = tools.ExecuteCmd("salt",  nodelist[i], "service.enable", "crio")
 			if success != true {
 				if err := stream.Send(&pb.StatusReply{Success: false, Message: nodelist[i] + ": " + message}); err != nil {
 					log.Errorf("Send message failed: %s", err)
@@ -137,7 +137,7 @@ func AddNode(in *pb.AddNodeRequest, stream pb.Kubeadm_AddNodeServer) error {
 				failed++
 				return
 			}
-			success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodelist[i], "service.start", "kubelet")
+			success, message = tools.ExecuteCmd("salt",  nodelist[i], "service.start", "kubelet")
 			if success != true {
 				if err := stream.Send(&pb.StatusReply{Success: false, Message: nodelist[i] + ": " + message}); err != nil {
 					log.Errorf("Send message failed: %s", err)
@@ -145,7 +145,7 @@ func AddNode(in *pb.AddNodeRequest, stream pb.Kubeadm_AddNodeServer) error {
 				failed++
 				return
 			}
-			success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodelist[i], "service.enable", "kubelet")
+			success, message = tools.ExecuteCmd("salt",  nodelist[i], "service.enable", "kubelet")
 			if success != true {
 				if err := stream.Send(&pb.StatusReply{Success: false, Message: nodelist[i] + ": " + message}); err != nil {
 					log.Errorf("Send message failed: %s", err)
@@ -156,7 +156,7 @@ func AddNode(in *pb.AddNodeRequest, stream pb.Kubeadm_AddNodeServer) error {
 
 			stream.Send(&pb.StatusReply{Success: true, Message: nodelist[i] + ": joining cluster..."})
 
-			success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodelist[i], "cmd.run", "\""+joincmd+"\"")
+			success, message = tools.ExecuteCmd("salt",  nodelist[i], "cmd.run", "\""+joincmd+"\"")
 			if success != true {
 				if err := stream.Send(&pb.StatusReply{Success: false, Message: nodelist[i] + ": " + message}); err != nil {
 					log.Errorf("Send message failed: %s", err)
@@ -164,7 +164,7 @@ func AddNode(in *pb.AddNodeRequest, stream pb.Kubeadm_AddNodeServer) error {
 				failed++
 				return
 			}
-			success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodelist[i], "grains.append", "kubicd", "kubic-"+nodeType+"-node")
+			success, message = tools.ExecuteCmd("salt",  nodelist[i], "grains.append", "kubicd", "kubic-"+nodeType+"-node")
 			if success != true {
 				if err := stream.Send(&pb.StatusReply{Success: false, Message: nodelist[i] + ": " + message}); err != nil {
 					log.Errorf("Send message failed: %s", err)
@@ -173,7 +173,7 @@ func AddNode(in *pb.AddNodeRequest, stream pb.Kubeadm_AddNodeServer) error {
 				return
 			}
 			// Configure transactinal-update
-			success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodelist[i], "cmd.run", "if [ -f /etc/transactional-update.conf ]; then grep -q ^REBOOT_METHOD= /etc/transactional-update.conf && sed -i -e 's|REBOOT_METHOD=.*|REBOOT_METHOD=kured|g' /etc/transactional-update.conf || echo REBOOT_METHOD=kured >> /etc/transactional-update.conf ; else echo REBOOT_METHOD=kured > /etc/transactional-update.conf ; fi")
+			success, message = tools.ExecuteCmd("salt",  nodelist[i], "cmd.run", "if [ -f /etc/transactional-update.conf ]; then grep -q ^REBOOT_METHOD= /etc/transactional-update.conf && sed -i -e 's|REBOOT_METHOD=.*|REBOOT_METHOD=kured|g' /etc/transactional-update.conf || echo REBOOT_METHOD=kured >> /etc/transactional-update.conf ; else echo REBOOT_METHOD=kured > /etc/transactional-update.conf ; fi")
 			if success != true {
 				if err := stream.Send(&pb.StatusReply{Success: false, Message: nodelist[i] + ": " + message}); err != nil {
 					log.Errorf("Send message failed: %s", err)
@@ -185,7 +185,7 @@ func AddNode(in *pb.AddNodeRequest, stream pb.Kubeadm_AddNodeServer) error {
 			if len(haproxy_salt) > 0 {
 				stream.Send(&pb.StatusReply{Success: true, Message: nodelist[i] + ": adding node to haproxy loadbalancer..."})
 
-				success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", haproxy_salt, "cmd.run", "haproxycfg server add "+nodelist[i])
+				success, message = tools.ExecuteCmd("salt",  haproxy_salt, "cmd.run", "haproxycfg server add "+nodelist[i])
 				if success != true {
 					if err := stream.Send(&pb.StatusReply{Success: false, Message: nodelist[i] + ": " + message}); err != nil {
 						log.Errorf("Send message failed: %s", err)

--- a/pkg/kubeadm/initMaster.go
+++ b/pkg/kubeadm/initMaster.go
@@ -51,7 +51,7 @@ func update_cfg(file string, key string, value string) error {
 
 func executeCmdSalt(salt string, command string, arg ...string) (bool, string) {
 	if len(salt) > 0 {
-		return tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", salt, "cmd.run", command+" "+strings.Join(arg[:], " "))
+		return tools.ExecuteCmd("salt", salt, "cmd.run", command+" "+strings.Join(arg[:], " "))
 	} else {
 		return tools.ExecuteCmd(command, arg...)
 	}
@@ -60,7 +60,7 @@ func executeCmdSalt(salt string, command string, arg ...string) (bool, string) {
 // exists returns whether the given file or directory exists
 func exists(path string, salt string) (bool, error) {
 	if len(salt) > 0 {
-		success, message := tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", "--out=txt", salt, "file.access", path, "f")
+		success, message := tools.ExecuteCmd("salt", "--out=txt", salt, "file.access", path, "f")
 		if success != true {
 			return false, errors.New(message)
 		}
@@ -178,7 +178,7 @@ func InitMaster(in *pb.InitRequest, stream pb.Kubeadm_InitMasterServer) error {
 				}
 				return nil
 			}
-			success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", in.Haproxy, "cmd.run",
+			success, message = tools.ExecuteCmd("salt", in.Haproxy, "cmd.run",
 				"\"haproxycfg init --force "+in.MultiMaster+" "+hostname+"\"")
 			if success != true {
 				if err := stream.Send(&pb.StatusReply{Success: false, Message: message}); err != nil {
@@ -333,7 +333,7 @@ func InitMaster(in *pb.InitRequest, stream pb.Kubeadm_InitMasterServer) error {
 		// Get kubernetes/admin.conf for kubectl calls
 		tools.ExecuteCmd("mkdir", "/etc/kubernetes")
 		log.Infof("Download /etc/kubernetes/admin.conf")
-		success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", "--out=newline_values_only",
+		success, message = tools.ExecuteCmd("salt", "--out=newline_values_only",
 			"--out-file=/etc/kubernetes/admin.conf", arg_salt,
 			"cmd.run", "cat /etc/kubernetes/admin.conf")
 		if success != true {
@@ -391,7 +391,7 @@ func InitMaster(in *pb.InitRequest, stream pb.Kubeadm_InitMasterServer) error {
 		return nil
 	}
 	if len(arg_salt) > 0 {
-		success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", arg_salt, "grains.append", "kubicd", "kubic-master-node")
+		success, message = tools.ExecuteCmd("salt", arg_salt, "grains.append", "kubicd", "kubic-master-node")
 		if success != true {
 			if err := stream.Send(&pb.StatusReply{Success: success, Message: message}); err != nil {
 				return err

--- a/pkg/kubeadm/rebootNode.go
+++ b/pkg/kubeadm/rebootNode.go
@@ -31,7 +31,7 @@ func RebootNode(nodeName string) (bool, string) {
 		return success, message
 	}
 
-	success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodeName, "system.reboot")
+	success, message = tools.ExecuteCmd("salt",  nodeName, "system.reboot")
 	if success != true {
 		return success, message
 	}

--- a/pkg/kubeadm/removeNode.go
+++ b/pkg/kubeadm/removeNode.go
@@ -46,9 +46,9 @@ func RemoveNode(in *pb.RemoveNodeRequest, stream pb.Kubeadm_RemoveNodeServer) er
 		var message string
 
 		if strings.Index(in.NodeNames, ",") >= 0 && strings.Index(in.NodeNames, "[") == -1 {
-			success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", "--out=txt", "-L", in.NodeNames, "grains.get", "kubicd")
+			success, message = tools.ExecuteCmd("salt",  "--out=txt", "-L", in.NodeNames, "grains.get", "kubicd")
 		} else {
-			success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", "--out=txt", in.NodeNames, "grains.get", "kubicd")
+			success, message = tools.ExecuteCmd("salt",  "--out=txt", in.NodeNames, "grains.get", "kubicd")
 		}
 		if success != true {
 			if err := stream.Send(&pb.StatusReply{Success: false, Message: message}); err != nil {
@@ -92,7 +92,7 @@ func RemoveNode(in *pb.RemoveNodeRequest, stream pb.Kubeadm_RemoveNodeServer) er
 			// If loadbalancer is known, remove from haproxy
 			if len(haproxy_salt) > 0 {
 				stream.Send(&pb.StatusReply{Success: true, Message: nodelist[i] + ": removing node from haproxy loadbalancer..."})
-				success, message := tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", haproxy_salt, "cmd.run", "haproxycfg server remove "+nodelist[i])
+				success, message := tools.ExecuteCmd("salt",  haproxy_salt, "cmd.run", "haproxycfg server remove "+nodelist[i])
 				if success != true {
 					if err := stream.Send(&pb.StatusReply{Success: false, Message: nodelist[i] + ": " + message}); err != nil {
 						log.Errorf("Send message failed: %s", err)

--- a/pkg/kubeadm/reset.go
+++ b/pkg/kubeadm/reset.go
@@ -101,7 +101,7 @@ func ResetNode(nodeName string, send OutputStream) (bool, string) {
 	/* reset the node. Even if this fails, continue cleanup, but
 	   report back */
 	send(true, nodeName+": reset node...")
-	success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodeName,
+	success, message = tools.ExecuteCmd("salt",  nodeName,
 		"cmd.run", "kubeadm reset --force")
 	if success != true {
 		send(success, nodeName+": "+message+" (ignored)")
@@ -110,18 +110,18 @@ func ResetNode(nodeName string, send OutputStream) (bool, string) {
 
 	send(true, nodeName+": cleanup after kubeadm...")
 	/* Try some system cleanup, ignore if fails */
-	tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodeName, "cmd.run",
+	tools.ExecuteCmd("salt",  nodeName, "cmd.run",
 		"sed -i -e 's|^REBOOT_METHOD=kured|REBOOT_METHOD=auto|g' /etc/transactional-update.conf")
-	tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodeName, "grains.delkey", "kubicd")
-	tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodeName, "cmd.run",
+	tools.ExecuteCmd("salt",  nodeName, "grains.delkey", "kubicd")
+	tools.ExecuteCmd("salt",  nodeName, "cmd.run",
 		"\"iptables -F && iptables -t nat -F && iptables -t mangle -F && iptables -X\"")
-	tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodeName, "cmd.run", "\"rm -rf /var/lib/etcd/*\"")
-	tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodeName, "cmd.run", "\"rm -rf /var/lib/cni/*\"")
-	tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodeName, "cmd.run", "\"ip link delete cni0;  ip link delete flannel.1\"")
-	tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodeName, "service.disable", "kubelet")
-	tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodeName, "service.stop", "kubelet")
-	tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodeName, "service.disable", "crio")
-	tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodeName, "service.stop", "crio")
+	tools.ExecuteCmd("salt",  nodeName, "cmd.run", "\"rm -rf /var/lib/etcd/*\"")
+	tools.ExecuteCmd("salt",  nodeName, "cmd.run", "\"rm -rf /var/lib/cni/*\"")
+	tools.ExecuteCmd("salt",  nodeName, "cmd.run", "\"ip link delete cni0;  ip link delete flannel.1\"")
+	tools.ExecuteCmd("salt",  nodeName, "service.disable", "kubelet")
+	tools.ExecuteCmd("salt",  nodeName, "service.stop", "kubelet")
+	tools.ExecuteCmd("salt",  nodeName, "service.disable", "crio")
+	tools.ExecuteCmd("salt",  nodeName, "service.stop", "crio")
 
 	/* ignore if we cannot delete the node*/
 	send(true, nodeName+": final node deletion...")

--- a/pkg/kubeadm/upgradeKubernetes.go
+++ b/pkg/kubeadm/upgradeKubernetes.go
@@ -139,18 +139,18 @@ func upgradeNodes(in *pb.UpgradeRequest,
 			// if draining fails, ignore
 			tools.DrainNode(hostname, "")
 
-			success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodelist[i], "cmd.run",
+			success, message = tools.ExecuteCmd("salt",  nodelist[i], "cmd.run",
 				"\"kubeadm upgrade node\"")
 			if success != true {
 				failedNodes = failedNodes + nodelist[i] + " (kubeadm), "
 			} else {
 				// Update kubelet
-				success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodelist[i], "cmd.run",
+				success, message = tools.ExecuteCmd("salt",  nodelist[i], "cmd.run",
 					"\"sed -i s/KUBELET_VER=.*/KUBELET_VER="+kubelet_version+"/ /etc/sysconfig/kubelet\"")
 				if success != true {
 					failedNodes = failedNodes + nodelist[i] + " (kubelet_ver), "
 				} else {
-					success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", nodelist[i], "service.restart", "kubelet")
+					success, message = tools.ExecuteCmd("salt",  nodelist[i], "service.restart", "kubelet")
 					if success != true {
 						failedNodes = failedNodes + nodelist[i] + " (kubelet), "
 					}

--- a/pkg/tools/getKubeadmVersion.go
+++ b/pkg/tools/getKubeadmVersion.go
@@ -23,7 +23,7 @@ func GetKubeadmVersion(salt string) (bool, string) {
 	var success bool
 	var message string
 	if len(salt) > 0 {
-		success, message = ExecuteCmd("salt", "--module-executors='[direct_call]'", "--out=txt", salt, "cmd.run", "rpm -q --qf '%{VERSION}' kubernetes-kubeadm")
+		success, message = ExecuteCmd("salt",  "--out=txt", salt, "cmd.run", "rpm -q --qf '%{VERSION}' kubernetes-kubeadm")
 		message = strings.Replace(message, "\n", "", -1)
 		i := strings.Index(message, ":") + 1
 		message = strings.TrimSpace(message[i:])

--- a/pkg/tools/getListOfNodes.go
+++ b/pkg/tools/getListOfNodes.go
@@ -25,7 +25,7 @@ func GetListOfNodes(role string) (bool, string, []string) {
 	}
 
 	// Get list of all nodes of this role
-	success, message := ExecuteCmd("salt", "--module-executors='[direct_call]'", "-G", "kubicd:kubic-"+role+"-node", "grains.get", "kubic-"+role+"-node")
+	success, message := ExecuteCmd("salt",  "-G", "kubicd:kubic-"+role+"-node", "grains.get", "kubic-"+role+"-node")
 	if success != true {
 		return success, message, nil
 	}

--- a/pkg/tools/getNodeName.go
+++ b/pkg/tools/getNodeName.go
@@ -23,7 +23,7 @@ func GetNodeName(target string) (string, error) {
 
 	// salt host names are not identical with kubernetes node name.
 	// Output of hostname should be identical to node name
-	success, message := ExecuteCmd("salt", "--module-executors='[direct_call]'", target, "network.get_hostname")
+	success, message := ExecuteCmd("salt",  target, "network.get_hostname")
 	if success != true {
 		return target, errors.New(message)
 	}

--- a/pkg/yomi/install.go
+++ b/pkg/yomi/install.go
@@ -39,7 +39,7 @@ func Install(in *pb.InstallRequest, stream pb.Yomi_InstallServer) error {
 	}
 
 	// make sure latest modules are used on minion
-	success, message := tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", in.Saltnode, "saltutil.sync_all")
+	success, message := tools.ExecuteCmd("salt",  in.Saltnode, "saltutil.sync_all")
 	if success != true {
 		if err := stream.Send(&pb.StatusReply{Success: false,
 			Message: message}); err != nil {
@@ -49,7 +49,7 @@ func Install(in *pb.InstallRequest, stream pb.Yomi_InstallServer) error {
 	}
 
 	// wipe harddisk, else salt will not re-create them
-	success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", in.Saltnode, "state.apply", "yomi.storage.wipe")
+	success, message = tools.ExecuteCmd("salt",  in.Saltnode, "state.apply", "yomi.storage.wipe")
 	if success != true {
 		if err := stream.Send(&pb.StatusReply{Success: false,
 			Message: message}); err != nil {
@@ -59,7 +59,7 @@ func Install(in *pb.InstallRequest, stream pb.Yomi_InstallServer) error {
 	}
 
 	// Do final installation
-	success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", in.Saltnode, "state.sls", "yomi.installer")
+	success, message = tools.ExecuteCmd("salt",  in.Saltnode, "state.sls", "yomi.installer")
 	if success != true {
 		if err := stream.Send(&pb.StatusReply{Success: false,
 			Message: message}); err != nil {

--- a/pkg/yomi/prepareConfig.go
+++ b/pkg/yomi/prepareConfig.go
@@ -74,7 +74,7 @@ func PrepareConfig(in *pb.PrepareConfigRequest, stream pb.Yomi_PrepareConfigServ
 	}
 
 	// make sure latest modules are used on minion
-	success, message := tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", in.Saltnode, "saltutil.sync_all")
+	success, message := tools.ExecuteCmd("salt",  in.Saltnode, "saltutil.sync_all")
 	if success != true {
 		if err := stream.Send(&pb.StatusReply{Success: false,
 			Message: message}); err != nil {
@@ -117,7 +117,7 @@ func PrepareConfig(in *pb.PrepareConfigRequest, stream pb.Yomi_PrepareConfigServ
 	useEfi := false
 	if in.Efi == 0 {
 		// UEFI or BIOS?
-		success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", "--out=txt", in.Saltnode, "cmd.run",
+		success, message = tools.ExecuteCmd("salt",  "--out=txt", in.Saltnode, "cmd.run",
 			"test -f /sys/firmware/efi/systab && echo true || echo false")
 		if success != true {
 			if err := stream.Send(&pb.StatusReply{Success: false,
@@ -154,7 +154,7 @@ func PrepareConfig(in *pb.PrepareConfigRequest, stream pb.Yomi_PrepareConfigServ
 	useBareMetal := false
 	if in.Baremetal == 0 {
 		// bare metal or virtualisation?
-		success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", "--out=txt", in.Saltnode, "cmd.run", "systemd-detect-virt")
+		success, message = tools.ExecuteCmd("salt",  "--out=txt", in.Saltnode, "cmd.run", "systemd-detect-virt")
 		if success != true {
 			if err := stream.Send(&pb.StatusReply{Success: false,
 				Message: message}); err != nil {
@@ -191,7 +191,7 @@ func PrepareConfig(in *pb.PrepareConfigRequest, stream pb.Yomi_PrepareConfigServ
 	if len(in.Disk) > 0 {
 		entry = "{% set disk = '" + in.Disk + "' %}\n"
 	} else {
-		success, message = tools.ExecuteCmd("salt", "--module-executors='[direct_call]'", "--out=json", in.Saltnode, "devices.hwinfo", "disk")
+		success, message = tools.ExecuteCmd("salt",  "--out=json", in.Saltnode, "devices.hwinfo", "disk")
 		if success != true {
 			if err := stream.Send(&pb.StatusReply{Success: false,
 				Message: message}); err != nil {


### PR DESCRIPTION
All nodes are giving the following error:
```
ERROR executing 'cmd.run': Executor '[direct_call]' is not available)
```

this is from a fresh install, with no changes done on any of the nodes (default setup)

when one runs salt with (and without) `--module-executors='[direct_call]'` it works fine, but when ran through `kubicctl`, it fails. It looks like kubicctl loses access to `'[direct_call]'` which causes these failures. 

```
k8s-master-1:~ # salt --module-executors='[direct_call]' 'k8s-lb-1.MYDOMAIN.com' cmd.run 'hostname'
k8s-lb-1.MYDOMAIN.com:
    k8s-lb-1
k8s-master-1:~ # salt 'k8s-lb-1.MYDOMAIN.com' cmd.run 'hostname'
k8s-lb-1.MYDOMAIN.com:
    k8s-lb-1
```
via kubicctl:
```
k8s-master-1:~ # kubicctl init --haproxy=k8s-lb-1.MYDOMAIN.com --multi-master=k8s-lb-1.MYDOMAIN.com
Initializing kubernetes master can take several minutes, please be patient.
Setting up multi-master kubernetes node (reacheable as 'k8s-lb-1.MYDOMAIN.com') with weave
Configure haproxy on node k8s-lb-1.MYDOMAIN.com
Error invoking salt: exit status 1
(k8s-lb-1.MYDOMAIN.com:
    ERROR executing 'cmd.run': Executor '[direct_call]' is not available)
```

execution time is slightly slower without the module, but it still works the way it should

long-term solution, would be to use a different tool (create a new one, specific to kubicctl, or use chef/puppet/etc and not saltstack)

if you are open to such a change, let me know and I can help out with that